### PR TITLE
PPR api add missing legacy registration and vehicle types.

### DIFF
--- a/src/registry_schemas/example_data/common/__init__.py
+++ b/src/registry_schemas/example_data/common/__init__.py
@@ -15,14 +15,7 @@
 
 These can be used in other tests as basis for the JSON registration statements.
 """
-from .schema_data import (
-    ADDRESS,
-    PARTY,
-    PAYMENT_REFERENCE,
-    PERSON_NAME,
-    USER,
-    USER_PROFILE
-)
+from .schema_data import ADDRESS, PARTY, PAYMENT_REFERENCE, PERSON_NAME, USER, USER_PROFILE
 
 
 __all__ = [

--- a/src/registry_schemas/example_data/ppr/__init__.py
+++ b/src/registry_schemas/example_data/ppr/__init__.py
@@ -38,7 +38,7 @@ from .schema_data import (
     SEARCH_QUERY,
     SEARCH_QUERY_RESULT,
     SEARCH_SUMMARY,
-    VEHICLE_COLLATERAL
+    VEHICLE_COLLATERAL,
 )
 
 

--- a/src/registry_schemas/flask/schema_services.py
+++ b/src/registry_schemas/flask/schema_services.py
@@ -22,7 +22,8 @@ import json
 
 from flask import g
 
-from registry_schemas import get_schema_store, validate as schema_validate
+from registry_schemas import get_schema_store
+from registry_schemas import validate as schema_validate
 
 
 class SchemaServices():

--- a/src/registry_schemas/schemas/ppr/searchSummary.json
+++ b/src/registry_schemas/schemas/ppr/searchSummary.json
@@ -28,8 +28,9 @@
                 "registrationType": {
                     "type": "string",
                     "maxLength": 2,
-                    "enum": ["SA", "RL", "FR", "LT", "MH", "SG", "FL", "FA", "FS", "MR"],
-                    "description": "Specifies the type of Financing Statement."
+                    "enum": ["SA", "RL", "FR", "LT", "MH", "SG", "FL", "FA", "FS", "MR", "CC", "CT", "DP", "ET", "FO", "FT", "HR", "IP", "LO", "MI", "OT"
+                        , "PG", "PS", "IT", "RA", "SS", "TL", "HN", "ML", "MN", "PN", "WL", "TF"],
+                    "description": "Specifies the type of Financing Statement. Includes all legacy registration types."
                 },
                 "debtor": {
                     "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/common/party"

--- a/src/registry_schemas/schemas/ppr/vehicleCollateral.json
+++ b/src/registry_schemas/schemas/ppr/vehicleCollateral.json
@@ -7,7 +7,7 @@
     "properties": {
         "type": {
             "type": "string",
-            "enum": [ "AC", "AF", "BO", "EV", "MH", "MV", "OB", "TR"],
+            "enum": [ "AC", "AF", "AP", "BO", "EV", "MH", "MV", "OB", "TR"],
             "maxLength": 2,
             "description": "Specifies the type of vehicle."
         },

--- a/tests/unit/common/test_address.py
+++ b/tests/unit/common/test_address.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Suite to ensure the common address schema is valid.
-
-"""
+"""Test Suite to ensure the common address schema is valid."""
 import copy
 
 from registry_schemas import validate
@@ -48,7 +46,7 @@ def test_valid_address_null_region():
 
 
 def test_invalid_address_street():
-    """Assert that an invalid address fails - street too long"""
+    """Assert that an invalid address fails - street too long."""
     address = copy.deepcopy(ADDRESS)
     address['street'] = 'This is a really long string, over the 50 char maximum.'
 
@@ -63,7 +61,7 @@ def test_invalid_address_street():
 
 
 def test_invalid_address_city():
-    """Assert that an invalid address fails - city too long"""
+    """Assert that an invalid address fails - city too long."""
     address = copy.deepcopy(ADDRESS)
     address['city'] = 'This is a really long string, over the 40 char maximum'
 
@@ -93,7 +91,7 @@ def test_invalid_address_postal():
 
 
 def test_invalid_address_street_missing():
-    """Assert that an invalid address fails - required street missing"""
+    """Assert that an invalid address fails - required street missing."""
     address = copy.deepcopy(ADDRESS)
     del address['street']
 
@@ -136,6 +134,7 @@ def test_invalid_address_missing_region():
 
     assert not is_valid
 
+
 def test_invalid_address_postal_missing():
     """Assert that an invalid address fails - required postal code missing."""
     address = copy.deepcopy(ADDRESS)
@@ -149,5 +148,3 @@ def test_invalid_address_postal_missing():
     print(errors)
 
     assert not is_valid
-
-

--- a/tests/unit/common/test_party.py
+++ b/tests/unit/common/test_party.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Suite to ensure the PPR party schema is valid.
-
-"""
+"""Test Suite to ensure the PPR party schema is valid."""
 import copy
 
 from registry_schemas import validate
@@ -35,7 +33,7 @@ def test_valid_party_person():
 def test_valid_party_business():
     """Assert that the schema is performing as expected for a business party."""
     party = copy.deepcopy(PARTY)
-    party['businessName'] = 'BUSINESS NAME' 
+    party['businessName'] = 'BUSINESS NAME'
     del party['personName']
     is_valid, errors = validate(party, 'party', 'common')
 
@@ -50,7 +48,7 @@ def test_valid_party_business():
 def test_valid_party_code():
     """Assert that the schema is performing as expected for a party code."""
     party = copy.deepcopy(PARTY)
-    party['code'] = '1234' 
+    party['code'] = '1234'
     del party['personName']
     del party['address']
     del party['emailAddress']
@@ -77,7 +75,6 @@ def test_invalid_party_missing_lastname():
     print(errors)
 
     assert not is_valid
-
 
 
 def test_invalid_party_birthdate():
@@ -133,7 +130,7 @@ def test_invalid_party_missing_business_address():
     del party['address']
     del party['partyId']
     party['businessName'] = 'BUSINESS NAME'
-    
+
     is_valid, errors = validate(party, 'party', 'common')
 
     if errors:

--- a/tests/unit/common/test_payment_reference.py
+++ b/tests/unit/common/test_payment_reference.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Suite to ensure the PPR payment reference schema is valid.
-
-"""
+"""Test Suite to ensure the PPR payment reference schema is valid."""
 import copy
 
 from registry_schemas import validate

--- a/tests/unit/common/test_person_name.py
+++ b/tests/unit/common/test_person_name.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Suite to ensure the common person name schema is valid.
-
-"""
+"""Test Suite to ensure the common person name schema is valid."""
 import copy
 
 from registry_schemas import validate
@@ -105,4 +103,3 @@ def test_invalid_person_missing_last():
     print(errors)
 
     assert not is_valid
-

--- a/tests/unit/ppr/test_amendment_statement.py
+++ b/tests/unit/ppr/test_amendment_statement.py
@@ -11,16 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Suite to ensure the PPR Amendment Statement (request and response) schema is valid.
-
-"""
+"""Test Suite to ensure the PPR Amendment Statement (request and response) schema is valid."""
 import copy
 
 from registry_schemas import validate
 from registry_schemas.example_data.ppr import AMENDMENT_STATEMENT
 
 
-def test_valid_amendment_request_AM():
+def test_valid_amendment_request_am():
     """Assert that the schema is performing as expected for an amendment request."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
     statement['changeType'] = 'AM'
@@ -39,7 +37,7 @@ def test_valid_amendment_request_AM():
     assert is_valid
 
 
-def test_valid_amendment_request_CO():
+def test_valid_amendment_request_co():
     """Assert that the schema is performing as expected for a court order amendment request."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
     del statement['createDateTime']
@@ -636,7 +634,7 @@ def test_invalid_amendment_missing_changetype():
     assert not is_valid
 
 
-def test_invalid_amendment_CO_missing_info():
+def test_invalid_amendment_co_missing_info():
     """Assert that an invalid amendment statement fails - CO change type missing court order information."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
     del statement['baseDebtor']
@@ -651,5 +649,3 @@ def test_invalid_amendment_CO_missing_info():
     print(errors)
 
     assert not is_valid
-
-

--- a/tests/unit/ppr/test_base_debtor.py
+++ b/tests/unit/ppr/test_base_debtor.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Suite to ensure the PPR base debtor schema is valid.
-
-"""
+"""Test Suite to ensure the PPR base debtor schema is valid."""
 import copy
 
 from registry_schemas import validate
@@ -35,7 +33,7 @@ def test_valid_debtor_person():
 def test_valid_debtor_business():
     """Assert that the schema is performing as expected for a business debtor."""
     debtor = copy.deepcopy(BASE_DEBTOR)
-    debtor['businessName'] = 'BUSINESS NAME DEBTOR INC.' 
+    debtor['businessName'] = 'BUSINESS NAME DEBTOR INC.'
     del debtor['personName']
     is_valid, errors = validate(debtor, 'baseDebtor', 'ppr')
 
@@ -90,4 +88,3 @@ def test_invalid_debtor_missing_debtor():
     print(errors)
 
     assert not is_valid
-

--- a/tests/unit/ppr/test_change_statement.py
+++ b/tests/unit/ppr/test_change_statement.py
@@ -11,16 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Suite to ensure the PPR Change Statement (request and response) schema is valid.
-
-"""
+"""Test Suite to ensure the PPR Change Statement (request and response) schema is valid."""
 import copy
 
 from registry_schemas import validate
 from registry_schemas.example_data.ppr import CHANGE_STATEMENT
 
 
-def test_valid_change_request_AC_vehicle():
+def test_valid_change_request_ac_vehicle():
     """Assert that the schema is performing as expected for an add vehicle collateral change request."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'AC'
@@ -45,7 +43,7 @@ def test_valid_change_request_AC_vehicle():
     assert is_valid
 
 
-def test_valid_change_request_AC_general():
+def test_valid_change_request_ac_general():
     """Assert that the schema is performing as expected for an add general collateral change request."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'AC'
@@ -70,7 +68,7 @@ def test_valid_change_request_AC_general():
     assert is_valid
 
 
-def test_valid_change_request_AC_both():
+def test_valid_change_request_ac_both():
     """Assert that the schema is performing as expected for an add vehicle and general collateral change request."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'AC'
@@ -94,7 +92,7 @@ def test_valid_change_request_AC_both():
     assert is_valid
 
 
-def test_valid_change_request_DR():
+def test_valid_change_request_dr():
     """Assert that the schema is performing as expected for a debtor release change request."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'DR'
@@ -119,7 +117,7 @@ def test_valid_change_request_DR():
     assert is_valid
 
 
-def test_valid_change_request_DT():
+def test_valid_change_request_dt():
     """Assert that the schema is performing as expected for a debtor transfer change request."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'DT'
@@ -143,7 +141,7 @@ def test_valid_change_request_DT():
     assert is_valid
 
 
-def test_valid_change_request_PD():
+def test_valid_change_request_pd():
     """Assert that the schema is performing as expected for a partial discharge change request."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'PD'
@@ -168,7 +166,7 @@ def test_valid_change_request_PD():
     assert is_valid
 
 
-def test_valid_change_request_ST():
+def test_valid_change_request_st():
     """Assert that the schema is performing as expected for a secured party transfer change request."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'ST'
@@ -192,8 +190,8 @@ def test_valid_change_request_ST():
     assert is_valid
 
 
-def test_valid_change_request_SU_all():
-    """Assert that the schema is performing as expected for a subsitution of general and vehicle collateral change request."""
+def test_valid_change_request_su_all():
+    """Assert that the schema is performing as expected for a subsitution of general and vehicle collateral."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'SU'
     del statement['createDateTime']
@@ -203,7 +201,7 @@ def test_valid_change_request_SU_all():
     del statement['deleteDebtors']
     del statement['addSecuredParties']
     del statement['deleteSecuredParties']
- 
+
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')
 
     if errors:
@@ -214,7 +212,7 @@ def test_valid_change_request_SU_all():
     assert is_valid
 
 
-def test_valid_change_request_SU_vehicle():
+def test_valid_change_request_su_vehicle():
     """Assert that the schema is performing as expected for a subsitution of vehicle collateral change request."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'SU'
@@ -236,7 +234,7 @@ def test_valid_change_request_SU_vehicle():
     assert is_valid
 
 
-def test_valid_change_request_SU_general():
+def test_valid_change_request_su_general():
     """Assert that the schema is performing as expected for a subsitution of general collateral change request."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'SU'
@@ -256,7 +254,6 @@ def test_valid_change_request_SU_general():
     print(errors)
 
     assert is_valid
-
 
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')
 
@@ -283,7 +280,7 @@ def test_valid_change_response():
     assert is_valid
 
 
-def test_invalid_change_AC_missing_collateral():
+def test_invalid_change_ac_missing_collateral():
     """Assert that an invalid change statement fails - AC change but no add collateral."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     del statement['createDateTime']
@@ -302,7 +299,7 @@ def test_invalid_change_AC_missing_collateral():
     assert not is_valid
 
 
-def test_invalid_change_PD_missing_collateral():
+def test_invalid_change_pd_missing_collateral():
     """Assert that an invalid change statement fails - PD change but no delete collateral."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'PD'
@@ -322,7 +319,7 @@ def test_invalid_change_PD_missing_collateral():
     assert not is_valid
 
 
-def test_invalid_change_DR_missing_debtors():
+def test_invalid_change_dr_missing_debtors():
     """Assert that an invalid change statement fails - DC change but no delete debtors."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'DR'
@@ -341,7 +338,7 @@ def test_invalid_change_DR_missing_debtors():
     assert not is_valid
 
 
-def test_invalid_change_DT_missing_delete():
+def test_invalid_change_dt_missing_delete():
     """Assert that an invalid change statement fails - DT change but no delete debtors."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'DT'
@@ -360,7 +357,7 @@ def test_invalid_change_DT_missing_delete():
     assert not is_valid
 
 
-def test_invalid_change_DT_missing_add():
+def test_invalid_change_dt_missing_add():
     """Assert that an invalid change statement fails - DT change but no add debtors."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'DT'
@@ -379,7 +376,7 @@ def test_invalid_change_DT_missing_add():
     assert not is_valid
 
 
-def test_invalid_change_ST_missing_add():
+def test_invalid_change_st_missing_add():
     """Assert that an invalid change statement fails - ST change but no add secured parties."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'ST'
@@ -398,7 +395,7 @@ def test_invalid_change_ST_missing_add():
     assert not is_valid
 
 
-def test_invalid_change_ST_missing_delete():
+def test_invalid_change_st_missing_delete():
     """Assert that an invalid change statement fails - ST change but no delete secured parties."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'ST'
@@ -417,7 +414,7 @@ def test_invalid_change_ST_missing_delete():
     assert not is_valid
 
 
-def test_invalid_change_SU_missing_add():
+def test_invalid_change_su_missing_add():
     """Assert that an invalid change statement fails - SU change but no add collateral."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'SU'
@@ -437,7 +434,7 @@ def test_invalid_change_SU_missing_add():
     assert not is_valid
 
 
-def test_invalid_change_SU_missing_delete():
+def test_invalid_change_su_missing_delete():
     """Assert that an invalid change statement fails - SU change but no delete collateral."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'SU'
@@ -762,5 +759,3 @@ def test_invalid_change_missing_changetype():
     print(errors)
 
     assert not is_valid
-
-

--- a/tests/unit/ppr/test_client_party.py
+++ b/tests/unit/ppr/test_client_party.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Suite to ensure the PPR client party schema is valid.
-
-"""
+"""Test Suite to ensure the PPR client party schema is valid."""
 import copy
 
 from registry_schemas import validate
@@ -35,7 +33,7 @@ def test_valid_client_person():
 def test_valid_client_business():
     """Assert that the schema is performing as expected for a business client party."""
     party = copy.deepcopy(CLIENT_PARTY)
-    party['businessName'] = 'BUSINESS NAME' 
+    party['businessName'] = 'BUSINESS NAME'
     del party['personName']
     is_valid, errors = validate(party, 'clientParty', 'ppr')
 
@@ -212,6 +210,7 @@ def test_invalid_client_missing_business_address():
     print(errors)
 
     assert not is_valid
+
 
 def test_invalid_client_missing_business_contact():
     """Assert that an invalid client party fails - business contact is missing."""

--- a/tests/unit/ppr/test_court_order.py
+++ b/tests/unit/ppr/test_court_order.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Suite to ensure the PPR court order information schema is valid.
-
-"""
+"""Test Suite to ensure the PPR court order information schema is valid."""
 import copy
 
 from registry_schemas import validate
@@ -34,10 +32,10 @@ def test_valid_court_order():
 
 def test_invalid_court_order_missing_courtname():
     """Assert that an invalid court order fails - court name is missing."""
-    coInfo = copy.deepcopy(COURT_ORDER)
-    del coInfo['courtName']
+    co_info = copy.deepcopy(COURT_ORDER)
+    del co_info['courtName']
 
-    is_valid, errors = validate(coInfo, 'courtOrder', 'ppr')
+    is_valid, errors = validate(co_info, 'courtOrder', 'ppr')
 
     if errors:
         for err in errors:
@@ -49,10 +47,10 @@ def test_invalid_court_order_missing_courtname():
 
 def test_invalid_court_order_missing_courtregistry():
     """Assert that an invalid court order fails - court registry is missing."""
-    coInfo = copy.deepcopy(COURT_ORDER)
-    del coInfo['courtRegistry']
+    co_info = copy.deepcopy(COURT_ORDER)
+    del co_info['courtRegistry']
 
-    is_valid, errors = validate(coInfo, 'courtOrder', 'ppr')
+    is_valid, errors = validate(co_info, 'courtOrder', 'ppr')
 
     if errors:
         for err in errors:
@@ -64,10 +62,10 @@ def test_invalid_court_order_missing_courtregistry():
 
 def test_invalid_court_order_missing_filenumber():
     """Assert that an invalid court order fails - file number is missing."""
-    coInfo = copy.deepcopy(COURT_ORDER)
-    del coInfo['fileNumber']
+    co_info = copy.deepcopy(COURT_ORDER)
+    del co_info['fileNumber']
 
-    is_valid, errors = validate(coInfo, 'courtOrder', 'ppr')
+    is_valid, errors = validate(co_info, 'courtOrder', 'ppr')
 
     if errors:
         for err in errors:
@@ -79,10 +77,10 @@ def test_invalid_court_order_missing_filenumber():
 
 def test_invalid_court_order_missing_orderdate():
     """Assert that an invalid court order fails - order date is missing."""
-    coInfo = copy.deepcopy(COURT_ORDER)
-    del coInfo['orderDate']
+    co_info = copy.deepcopy(COURT_ORDER)
+    del co_info['orderDate']
 
-    is_valid, errors = validate(coInfo, 'courtOrder', 'ppr')
+    is_valid, errors = validate(co_info, 'courtOrder', 'ppr')
 
     if errors:
         for err in errors:
@@ -94,10 +92,10 @@ def test_invalid_court_order_missing_orderdate():
 
 def test_invalid_court_order_courtname():
     """Assert that an invalid court order fails - court name is too short."""
-    coInfo = copy.deepcopy(COURT_ORDER)
-    coInfo['courtName'] = 'xx'
+    co_info = copy.deepcopy(COURT_ORDER)
+    co_info['courtName'] = 'xx'
 
-    is_valid, errors = validate(coInfo, 'courtOrder', 'ppr')
+    is_valid, errors = validate(co_info, 'courtOrder', 'ppr')
 
     if errors:
         for err in errors:
@@ -109,10 +107,10 @@ def test_invalid_court_order_courtname():
 
 def test_invalid_court_order_courtregistry():
     """Assert that an invalid court order fails - court registry is too short."""
-    coInfo = copy.deepcopy(COURT_ORDER)
-    coInfo['courtRegistry'] = 'XX'
+    co_info = copy.deepcopy(COURT_ORDER)
+    co_info['courtRegistry'] = 'XX'
 
-    is_valid, errors = validate(coInfo, 'courtOrder', 'ppr')
+    is_valid, errors = validate(co_info, 'courtOrder', 'ppr')
 
     if errors:
         for err in errors:
@@ -124,10 +122,10 @@ def test_invalid_court_order_courtregistry():
 
 def test_invalid_court_order_filenumber():
     """Assert that an invalid court order fails - file number is too long."""
-    coInfo = copy.deepcopy(COURT_ORDER)
-    coInfo['fileNumber'] = 'FILE NUMBER TOO LONGXXXX'
+    co_info = copy.deepcopy(COURT_ORDER)
+    co_info['fileNumber'] = 'FILE NUMBER TOO LONGXXXX'
 
-    is_valid, errors = validate(coInfo, 'courtOrder', 'ppr')
+    is_valid, errors = validate(co_info, 'courtOrder', 'ppr')
 
     if errors:
         for err in errors:
@@ -139,10 +137,10 @@ def test_invalid_court_order_filenumber():
 
 def test_invalid_court_order_date():
     """Assert that an invalid court order fails - order date format is invalid."""
-    coInfo = copy.deepcopy(COURT_ORDER)
-    coInfo['orderDate'] = 'XXXXXXXX'
+    co_info = copy.deepcopy(COURT_ORDER)
+    co_info['orderDate'] = 'XXXXXXXX'
 
-    is_valid, errors = validate(coInfo, 'courtOrder', 'ppr')
+    is_valid, errors = validate(co_info, 'courtOrder', 'ppr')
 
     if errors:
         for err in errors:
@@ -150,13 +148,14 @@ def test_invalid_court_order_date():
     print(errors)
 
     assert not is_valid
+
 
 def test_invalid_court_order_effect():
     """Assert that an invalid court order fails - effect of order is too short."""
-    coInfo = copy.deepcopy(COURT_ORDER)
-    coInfo['effectOfOrder'] = 'XX'
+    co_info = copy.deepcopy(COURT_ORDER)
+    co_info['effectOfOrder'] = 'XX'
 
-    is_valid, errors = validate(coInfo, 'courtOrder', 'ppr')
+    is_valid, errors = validate(co_info, 'courtOrder', 'ppr')
 
     if errors:
         for err in errors:
@@ -164,5 +163,3 @@ def test_invalid_court_order_effect():
     print(errors)
 
     assert not is_valid
-
-

--- a/tests/unit/ppr/test_discharge_statement.py
+++ b/tests/unit/ppr/test_discharge_statement.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Suite to ensure the PPR Discharge Statement (request and response) schema is valid.
-
-"""
+"""Test Suite to ensure the PPR Discharge Statement (request and response) schema is valid."""
 import copy
 
 from registry_schemas import validate

--- a/tests/unit/ppr/test_draft.py
+++ b/tests/unit/ppr/test_draft.py
@@ -11,15 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Suite to ensure the PPR Draft schema is valid.
-
-"""
+"""Test Suite to ensure the PPR Draft schema is valid."""
 import copy
 
 from registry_schemas import validate
-from registry_schemas.example_data.ppr import DRAFT_FINANCING_STATEMENT
-from registry_schemas.example_data.ppr import DRAFT_CHANGE_STATEMENT
-from registry_schemas.example_data.ppr import DRAFT_AMENDMENT_STATEMENT
+from registry_schemas.example_data.ppr import (
+    DRAFT_AMENDMENT_STATEMENT,
+    DRAFT_CHANGE_STATEMENT,
+    DRAFT_FINANCING_STATEMENT,
+)
 
 
 def test_valid_draft_financing():
@@ -192,4 +192,3 @@ def test_invalid_draft_update():
     print(errors)
 
     assert not is_valid
-

--- a/tests/unit/ppr/test_draft_summary.py
+++ b/tests/unit/ppr/test_draft_summary.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Suite to ensure the PPR Draft Summary schema is valid.
-
-"""
+"""Test Suite to ensure the PPR Draft Summary schema is valid."""
 import copy
 
 from registry_schemas import validate
@@ -40,7 +38,6 @@ def test_valid_draft_summary_empty():
     del draft[0]
 
     is_valid, errors = validate(draft, 'draftSummary', 'ppr')
-
 
     if errors:
         for err in errors:
@@ -80,7 +77,7 @@ def test_invalid_draft_summary_missing_regtype():
     assert not is_valid
 
 
-def test_invalid_draft_summary_missing_docId():
+def test_invalid_draft_summary_missing_docid():
     """Assert that an invalid draft summary fails - document ID is missing."""
     draft = copy.deepcopy(DRAFT_SUMMARY)
     del draft[0]['documentId']
@@ -125,7 +122,7 @@ def test_invalid_draft_summary_missing_timestamp():
     assert not is_valid
 
 
-def test_invalid_draft_summary_docId():
+def test_invalid_draft_summary_docid():
     """Assert that an invalid draft summary fails - document Id is too long."""
     draft = copy.deepcopy(DRAFT_SUMMARY)
     draft[0]['documentId'] = 'XXXXXXXXXXXXX'
@@ -168,5 +165,3 @@ def test_invalid_draft_summary_regtype():
     print(errors)
 
     assert not is_valid
-
-

--- a/tests/unit/ppr/test_financing_statement.py
+++ b/tests/unit/ppr/test_financing_statement.py
@@ -11,16 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Suite to ensure the PPR Financing Statement (request and response) schema is valid.
-
-"""
+"""Test Suite to ensure the PPR Financing Statement (request and response) schema is valid."""
 import copy
 
 from registry_schemas import validate
 from registry_schemas.example_data.ppr import FINANCING_STATEMENT
 
 
-def test_valid_financing_request_SA():
+def test_valid_financing_request_sa():
     """Assert that the schema is performing as expected for a security agreement financing request."""
     statement = copy.deepcopy(FINANCING_STATEMENT)
     statement['type'] = 'SA'
@@ -41,7 +39,7 @@ def test_valid_financing_request_SA():
     assert is_valid
 
 
-def test_valid_financing_request_RL():
+def test_valid_financing_request_rl():
     """Assert that the schema is performing as expected for a repairer's lien financing request."""
     statement = copy.deepcopy(FINANCING_STATEMENT)
     statement['type'] = 'RL'
@@ -63,7 +61,7 @@ def test_valid_financing_request_RL():
     assert is_valid
 
 
-def test_valid_financing_request_FR():
+def test_valid_financing_request_fr():
     """Assert that the schema is performing as expected for a FR financing request."""
     statement = copy.deepcopy(FINANCING_STATEMENT)
     statement['type'] = 'FR'
@@ -88,7 +86,7 @@ def test_valid_financing_request_FR():
     assert is_valid
 
 
-def test_valid_financing_request_LT():
+def test_valid_financing_request_lt():
     """Assert that the schema is performing as expected for a land tax lien financing request."""
     statement = copy.deepcopy(FINANCING_STATEMENT)
     statement['type'] = 'LT'
@@ -111,7 +109,7 @@ def test_valid_financing_request_LT():
     assert is_valid
 
 
-def test_valid_financing_request_MH():
+def test_valid_financing_request_mh():
     """Assert that the schema is performing as expected for a manufactured home lien financing request."""
     statement = copy.deepcopy(FINANCING_STATEMENT)
     statement['type'] = 'MH'
@@ -133,7 +131,7 @@ def test_valid_financing_request_MH():
     assert is_valid
 
 
-def test_valid_financing_request_SG():
+def test_valid_financing_request_sg():
     """Assert that the schema is performing as expected for a sale of goods financing request."""
     statement = copy.deepcopy(FINANCING_STATEMENT)
     statement['type'] = 'SG'
@@ -155,7 +153,7 @@ def test_valid_financing_request_SG():
     assert is_valid
 
 
-def test_valid_financing_request_FL():
+def test_valid_financing_request_fl():
     """Assert that the schema is performing as expected for a forestry contractor lien financing request."""
     statement = copy.deepcopy(FINANCING_STATEMENT)
     statement['type'] = 'FL'
@@ -177,7 +175,7 @@ def test_valid_financing_request_FL():
     assert is_valid
 
 
-def test_valid_financing_request_FA():
+def test_valid_financing_request_fa():
     """Assert that the schema is performing as expected for a forestry contractor charge lien financing request."""
     statement = copy.deepcopy(FINANCING_STATEMENT)
     statement['type'] = 'FA'
@@ -199,7 +197,7 @@ def test_valid_financing_request_FA():
     assert is_valid
 
 
-def test_valid_financing_request_FS():
+def test_valid_financing_request_fs():
     """Assert that the schema is performing as expected for a forestry contractor subcharge lien financing request."""
     statement = copy.deepcopy(FINANCING_STATEMENT)
     statement['type'] = 'FS'
@@ -221,7 +219,7 @@ def test_valid_financing_request_FS():
     assert is_valid
 
 
-def test_valid_financing_request_MR():
+def test_valid_financing_request_mr():
     """Assert that the schema is performing as expected for a miscellaneous regulations act financing request."""
     statement = copy.deepcopy(FINANCING_STATEMENT)
     statement['type'] = 'MR'
@@ -243,7 +241,7 @@ def test_valid_financing_request_MR():
     assert is_valid
 
 
-def test_valid_financing_response_SA():
+def test_valid_financing_response_sa():
     """Assert that the schema is performing as expected for an financing response."""
     statement = copy.deepcopy(FINANCING_STATEMENT)
     del statement['lifeInfinite']
@@ -515,7 +513,6 @@ def test_invalid_financing_missing_secparties():
     assert not is_valid
 
 
-
 def test_invalid_financing_missing_debtors():
     """Assert that an invalid financing statement fails - debtors are missing."""
     statement = copy.deepcopy(FINANCING_STATEMENT)
@@ -545,4 +542,3 @@ def test_invalid_financing_missing_collateral():
     print(errors)
 
     assert not is_valid
-

--- a/tests/unit/ppr/test_financing_statement_history.py
+++ b/tests/unit/ppr/test_financing_statement_history.py
@@ -15,11 +15,13 @@
 import copy
 
 from registry_schemas import validate
-from registry_schemas.example_data.ppr import FINANCING_STATEMENT_HISTORY
-from registry_schemas.example_data.ppr import CHANGE_STATEMENT
-from registry_schemas.example_data.ppr import AMENDMENT_STATEMENT
-from registry_schemas.example_data.ppr import RENEWAL_STATEMENT
-from registry_schemas.example_data.ppr import DISCHARGE_STATEMENT
+from registry_schemas.example_data.ppr import (
+    AMENDMENT_STATEMENT,
+    CHANGE_STATEMENT,
+    DISCHARGE_STATEMENT,
+    FINANCING_STATEMENT_HISTORY,
+    RENEWAL_STATEMENT,
+)
 
 
 def test_valid_financing_history():

--- a/tests/unit/ppr/test_general_collateral.py
+++ b/tests/unit/ppr/test_general_collateral.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Suite to ensure the PPR general collateral schema is valid.
-
-"""
+"""Test Suite to ensure the PPR general collateral schema is valid."""
 import copy
 
 from registry_schemas import validate
@@ -75,4 +73,3 @@ def test_invalid_general_collateral_missing_description():
     print(errors)
 
     assert not is_valid
-

--- a/tests/unit/ppr/test_renewal_statement.py
+++ b/tests/unit/ppr/test_renewal_statement.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Suite to ensure the PPR Renewal Statement (request and response) schema is valid.
-
-"""
+"""Test Suite to ensure the PPR Renewal Statement (request and response) schema is valid."""
 import copy
 
 from registry_schemas import validate
@@ -38,7 +36,7 @@ def test_valid_renewal_request():
     assert is_valid
 
 
-def test_valid_renewal_RL_request():
+def test_valid_renewal_rl_request():
     """Assert that the schema is performing as expected for a repairer's lien renewal request."""
     statement = copy.deepcopy(RENEWAL_STATEMENT)
     del statement['expiryDate']

--- a/tests/unit/ppr/test_search_query.py
+++ b/tests/unit/ppr/test_search_query.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Suite to ensure the PPR Search Query schema is valid.
-
-"""
+"""Test Suite to ensure the PPR Search Query schema is valid."""
 import copy
 
 from registry_schemas import validate
@@ -31,7 +29,6 @@ def test_valid_search_query_ind_debtor():
     del query['endDateTime']
 
     is_valid, errors = validate(query, 'searchQuery', 'ppr')
-
 
     if errors:
         for err in errors:
@@ -52,7 +49,6 @@ def test_valid_search_query_bus_debtor():
 
     is_valid, errors = validate(query, 'searchQuery', 'ppr')
 
-
     if errors:
         for err in errors:
             print(err.message)
@@ -69,7 +65,6 @@ def test_valid_search_query_airdot():
     query['criteria']['value'] = 'CFYXW'
 
     is_valid, errors = validate(query, 'searchQuery', 'ppr')
-
 
     if errors:
         for err in errors:
@@ -88,7 +83,6 @@ def test_valid_search_query_regnum():
 
     is_valid, errors = validate(query, 'searchQuery', 'ppr')
 
-
     if errors:
         for err in errors:
             print(err.message)
@@ -106,7 +100,6 @@ def test_valid_search_query_mhrnum():
 
     is_valid, errors = validate(query, 'searchQuery', 'ppr')
 
-
     if errors:
         for err in errors:
             print(err.message)
@@ -123,7 +116,6 @@ def test_valid_search_query_serialnum():
     query['criteria']['value'] = 'KM8J3CA46JU622994'
 
     is_valid, errors = validate(query, 'searchQuery', 'ppr')
-
 
     if errors:
         for err in errors:
@@ -253,7 +245,7 @@ def test_invalid_search_query_firstname():
     del query['criteria']['value']
     del query['criteria']['debtorName']['business']
     query['criteria']['debtorName']['first'] = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
- 
+
     is_valid, errors = validate(query, 'searchQuery', 'ppr')
 
     if errors:
@@ -270,7 +262,7 @@ def test_invalid_search_query_secondname():
     del query['criteria']['value']
     del query['criteria']['debtorName']['business']
     query['criteria']['debtorName']['second'] = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
- 
+
     is_valid, errors = validate(query, 'searchQuery', 'ppr')
 
     if errors:
@@ -281,14 +273,13 @@ def test_invalid_search_query_secondname():
     assert not is_valid
 
 
-
 def test_invalid_search_query_lastname():
     """Assert that an invalid search query fails - debtor last name is too long."""
     query = copy.deepcopy(SEARCH_QUERY)
     del query['criteria']['value']
     del query['criteria']['debtorName']['business']
     query['criteria']['debtorName']['last'] = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
- 
+
     is_valid, errors = validate(query, 'searchQuery', 'ppr')
 
     if errors:
@@ -348,4 +339,3 @@ def test_invalid_search_query_endts():
     print(errors)
 
     assert not is_valid
-

--- a/tests/unit/ppr/test_search_summary.py
+++ b/tests/unit/ppr/test_search_summary.py
@@ -14,8 +14,49 @@
 """Test Suite to ensure the PPR Search Summary schema is valid."""
 import copy
 
+import pytest
+
 from registry_schemas import validate
 from registry_schemas.example_data.ppr import SEARCH_SUMMARY
+
+
+# testdata pattern is ({registration type}, {is valid})
+TEST_DATA_REG_TYPE = [
+    ('CC', True),
+    ('CT', True),
+    ('DP', True),
+    ('ET', True),
+    ('FA', True),
+    ('FL', True),
+    ('FO', True),
+    ('FR', True),
+    ('FS', True),
+    ('FT', True),
+    ('HN', True),
+    ('HR', True),
+    ('IP', True),
+    ('IT', True),
+    ('LO', True),
+    ('LT', True),
+    ('MH', True),
+    ('MI', True),
+    ('ML', True),
+    ('MN', True),
+    ('MR', True),
+    ('OT', True),
+    ('PG', True),
+    ('PN', True),
+    ('PS', True),
+    ('RA', True),
+    ('RL', True),
+    ('SA', True),
+    ('SG', True),
+    ('SS', True),
+    ('TF', True),
+    ('TL', True),
+    ('WL', True),
+    ('XX', False),
+]
 
 
 def test_valid_search_summary():
@@ -86,6 +127,24 @@ def test_valid_search_summary_missing_regtype():
             print(err.message)
 
     assert is_valid
+
+
+@pytest.mark.parametrize('registration_type, valid', TEST_DATA_REG_TYPE)
+def test_search_summary_regtype(registration_type, valid):
+    """Assert the validation of all registration types."""
+    search = copy.deepcopy(SEARCH_SUMMARY)
+    search[0]['registrationType'] = registration_type
+
+    is_valid, errors = validate(search, 'searchSummary', 'ppr')
+
+    if errors:
+        for err in errors:
+            print(err.message)
+
+    if valid:
+        assert is_valid
+    else:
+        assert not is_valid
 
 
 def test_valid_search_summary_missing_create():

--- a/tests/unit/ppr/test_vehicle_collateral.py
+++ b/tests/unit/ppr/test_vehicle_collateral.py
@@ -11,145 +11,46 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Suite to ensure the PPR vehicle collateral schema is valid.
-
-"""
+"""Test Suite to ensure the PPR vehicle collateral schema is valid."""
 import copy
+
+import pytest
 
 from registry_schemas import validate
 from registry_schemas.example_data.ppr import VEHICLE_COLLATERAL
 
 
-def test_valid_vehicle_MV():
-    """Assert that the schema is performing as expected for MV type."""
-    is_valid, errors = validate(VEHICLE_COLLATERAL, 'vehicleCollateral', 'ppr')
+# testdata pattern is ({vehicle type}, {is valid})
+TEST_DATA_VEHICLE_TYPE = [
+    ('AC', True),
+    ('AF', True),
+    ('AP', True),
+    ('BO', True),
+    ('EV', True),
+    ('MH', True),
+    ('MV', True),
+    ('OB', True),
+    ('TR', True),
+    ('XX', False)
+]
 
-    if errors:
-        for err in errors:
-            print(err.message)
-    print(errors)
 
-    assert is_valid
-
-
-def test_valid_vehicle_AC():
-    """Assert that the schema is performing as expected for AC type."""
+@pytest.mark.parametrize('vehicle_type, valid', TEST_DATA_VEHICLE_TYPE)
+def test_vehicle_type(vehicle_type, valid):
+    """Assert that the schema is performing as expected for all serial collateral types."""
     vehicle = copy.deepcopy(VEHICLE_COLLATERAL)
-    vehicle['type'] = 'AC'
+    vehicle['type'] = vehicle_type
 
     is_valid, errors = validate(vehicle, 'vehicleCollateral', 'ppr')
 
     if errors:
         for err in errors:
             print(err.message)
-    print(errors)
 
-    assert is_valid
-
-
-def test_valid_vehicle_AF():
-    """Assert that the schema is performing as expected for AF type."""
-    vehicle = copy.deepcopy(VEHICLE_COLLATERAL)
-    vehicle['type'] = 'AF'
-
-    is_valid, errors = validate(vehicle, 'vehicleCollateral', 'ppr')
-
-    if errors:
-        for err in errors:
-            print(err.message)
-    print(errors)
-
-    assert is_valid
-
-
-def test_valid_vehicle_BO():
-    """Assert that the schema is performing as expected for BO type."""
-    vehicle = copy.deepcopy(VEHICLE_COLLATERAL)
-    vehicle['type'] = 'BO'
-
-    is_valid, errors = validate(vehicle, 'vehicleCollateral', 'ppr')
-
-    if errors:
-        for err in errors:
-            print(err.message)
-    print(errors)
-
-    assert is_valid
-
-
-def test_valid_vehicle_EV():
-    """Assert that the schema is performing as expected for EV type."""
-    vehicle = copy.deepcopy(VEHICLE_COLLATERAL)
-    vehicle['type'] = 'EV'
-
-    is_valid, errors = validate(vehicle, 'vehicleCollateral', 'ppr')
-
-    if errors:
-        for err in errors:
-            print(err.message)
-    print(errors)
-
-    assert is_valid
-
-
-def test_valid_vehicle_MH():
-    """Assert that the schema is performing as expected for MH type."""
-    vehicle = copy.deepcopy(VEHICLE_COLLATERAL)
-    vehicle['type'] = 'MH'
-
-    is_valid, errors = validate(vehicle, 'vehicleCollateral', 'ppr')
-
-    if errors:
-        for err in errors:
-            print(err.message)
-    print(errors)
-
-    assert is_valid
-
-
-def test_valid_vehicle_OB():
-    """Assert that the schema is performing as expected for OB type."""
-    vehicle = copy.deepcopy(VEHICLE_COLLATERAL)
-    vehicle['type'] = 'OB'
-
-    is_valid, errors = validate(vehicle, 'vehicleCollateral', 'ppr')
-
-    if errors:
-        for err in errors:
-            print(err.message)
-    print(errors)
-
-    assert is_valid
-
-
-def test_valid_vehicle_TR():
-    """Assert that the schema is performing as expected for TR type."""
-    vehicle = copy.deepcopy(VEHICLE_COLLATERAL)
-    vehicle['type'] = 'TR'
-
-    is_valid, errors = validate(vehicle, 'vehicleCollateral', 'ppr')
-
-    if errors:
-        for err in errors:
-            print(err.message)
-    print(errors)
-
-    assert is_valid
-
-
-def test_invalid_vehicle_type():
-    """Assert that an invalid vehicleCollateral fails - invalid type."""
-    vehicle = copy.deepcopy(VEHICLE_COLLATERAL)
-    vehicle['type'] = 'XX'
-
-    is_valid, errors = validate(vehicle, 'vehicleCollateral', 'ppr')
-
-    if errors:
-        for err in errors:
-            print(err.message)
-    print(errors)
-
-    assert not is_valid
+    if valid:
+        assert is_valid
+    else:
+        assert not is_valid
 
 
 def test_invalid_vehicle_serial():
@@ -212,7 +113,7 @@ def test_invalid_vehicle_model():
     assert not is_valid
 
 
-def test_invalid_vehicle_MHR_number():
+def test_invalid_vehicle_mhr_number():
     """Assert that an invalid vehicleCollateral fails - MHR registration number too long."""
     vehicle = copy.deepcopy(VEHICLE_COLLATERAL)
     vehicle['manufacturedHomeRegistrationNumber'] = '123456789'
@@ -255,4 +156,3 @@ def test_invalid_vehicle_missing_serial():
     print(errors)
 
     assert not is_valid
-


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#7639

*Description of changes:*
Search select results add all legacy registration types.
Add legacy vehicle type AP.
Flake 8 clean up of unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the registry-schemas license (Apache 2.0).
