### PR TITLE
PPR schemas replace baseDebtor, add otherTypeDescription

### DIFF
--- a/src/registry_schemas/example_data/ppr/__init__.py
+++ b/src/registry_schemas/example_data/ppr/__init__.py
@@ -18,10 +18,10 @@ These can be used in other tests as basis for the JSON registration statements.
 from .schema_data import (
     ADDRESS,
     AMENDMENT_STATEMENT,
-    BASE_DEBTOR,
     CHANGE_STATEMENT,
     CLIENT_PARTY,
     COURT_ORDER,
+    DEBTOR_NAME,
     DISCHARGE_STATEMENT,
     DRAFT_AMENDMENT_STATEMENT,
     DRAFT_CHANGE_STATEMENT,
@@ -45,10 +45,10 @@ from .schema_data import (
 __all__ = [
     'ADDRESS',
     'AMENDMENT_STATEMENT',
-    'BASE_DEBTOR',
     'CHANGE_STATEMENT',
     'CLIENT_PARTY',
     'COURT_ORDER',
+    'DEBTOR_NAME',
     'DISCHARGE_STATEMENT',
     'DRAFT_AMENDMENT_STATEMENT',
     'DRAFT_CHANGE_STATEMENT',

--- a/src/registry_schemas/example_data/ppr/schema_data.py
+++ b/src/registry_schemas/example_data/ppr/schema_data.py
@@ -28,7 +28,7 @@ AMENDMENT_STATEMENT = {
   'baseRegistrationNumber': '023001B',
   'clientReferenceId': 'A-00000402',
   'documentId': '1234567',
-  'baseDebtor': {
+  'debtorName': {
       'businessName': 'DEBTOR 1 INC.'
   },
   'registeringParty': {
@@ -149,20 +149,12 @@ AMENDMENT_STATEMENT = {
   }
 }
 
-BASE_DEBTOR = {
-  'personName': {
-    'first': 'Michael',
-    'middle': 'J',
-    'last': 'Smith'
-  }
-}
-
 CHANGE_STATEMENT = {
   'statementType': 'CHANGE_STATEMENT',
   'baseRegistrationNumber': '023001B',
   'clientReferenceId': 'A-00000402',
   'documentId': '1234567',
-  'baseDebtor': {
+  'debtorName': {
       'businessName': 'DEBTOR 1 INC.'
   },
   'registeringParty': {
@@ -304,12 +296,20 @@ COURT_ORDER = {
   'effectOfOrder': 'Court Order to remove James Smith as debtor.'
 }
 
+DEBTOR_NAME = {
+  'personName': {
+    'first': 'Michael',
+    'middle': 'J',
+    'last': 'Smith'
+  }
+}
+
 DISCHARGE_STATEMENT = {
   'statementType': 'DISCHARGE_STATEMENT',
   'baseRegistrationNumber': '023001B',
   'clientReferenceId': 'A-00000402',
   'documentId': '1234567',
-  'baseDebtor': {
+  'debtorName': {
       'businessName': 'DEBTOR 1 INC.'
   },
   'registeringParty': {
@@ -339,7 +339,7 @@ DRAFT_AMENDMENT_STATEMENT = {
     'description': 'Court Order debtor removal.',
     'changeType': 'CO',
     'clientReferenceId': 'A-00000402',
-    'baseDebtor': {
+    'debtorName': {
         'businessName': 'DEBTOR 1 INC.'
     },
     'registeringParty': {
@@ -380,7 +380,7 @@ DRAFT_CHANGE_STATEMENT = {
     'documentId': 'D0034003',
     'changeType': 'DT',
     'clientReferenceId': 'A-00000402',
-    'baseDebtor': {
+    'debtorName': {
         'businessName': 'DEBTOR 1 INC.'
     },
     'registeringParty': {
@@ -835,7 +835,7 @@ RENEWAL_STATEMENT = {
     'statementType': 'RENEWAL_STATEMENT',
     'baseRegistrationNumber': '023001B',
     'clientReferenceId': 'A-00000402',
-    'baseDebtor': {
+    'debtorName': {
         'businessName': 'DEBTOR 1 INC.'
     },
     'registeringParty': {

--- a/src/registry_schemas/flask/__init__.py
+++ b/src/registry_schemas/flask/__init__.py
@@ -20,4 +20,4 @@ Although it can work with other schemas and setups, it defaults to loading the R
 from .schema_services import SchemaServices
 
 
-__all__ = ('SchemaServices')
+__all__ = ['SchemaServices']

--- a/src/registry_schemas/flask/schema_services.py
+++ b/src/registry_schemas/flask/schema_services.py
@@ -59,7 +59,7 @@ class SchemaServices():
             store = None
 
     @property
-    def rsbc_schema_store(self) -> dict:  # pylint: disable=assigning-non-slot
+    def rsbc_schema_store(self) -> dict:
         """Return the cached schema_store.
 
         If this is running in a Flask context,
@@ -68,7 +68,7 @@ class SchemaServices():
         :return: dict
         """
         if 'rsbc_schema_store' not in g:
-            g.rsbc_schema_store = get_schema_store()
+            g.rsbc_schema_store = get_schema_store()  # pylint: disable=E0237
 
         return g.rsbc_schema_store
 

--- a/src/registry_schemas/flask/schema_services.py
+++ b/src/registry_schemas/flask/schema_services.py
@@ -59,7 +59,7 @@ class SchemaServices():
             store = None
 
     @property
-    def rsbc_schema_store(self) -> dict:
+    def rsbc_schema_store(self) -> dict:  # pylint: disable=assigning-non-slot
         """Return the cached schema_store.
 
         If this is running in a Flask context,

--- a/src/registry_schemas/schemas/ppr/amendmentStatement.json
+++ b/src/registry_schemas/schemas/ppr/amendmentStatement.json
@@ -32,8 +32,8 @@
             "maxLength": 10,
             "description": "Optional draft document identifier if the Amendment is in a draft state and has not yet been registered. If included when creating the statement the draft will be deleted."
         },
-        "baseDebtor": {
-            "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/ppr/baseDebtor"
+        "debtorName": {
+            "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/ppr/debtorName"
         },
         "registeringParty": {
             "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/common/party"
@@ -125,7 +125,7 @@
             "required": [
                 "baseRegistrationNumber",
                 "registeringParty",
-                "baseDebtor",
+                "debtorName",
                 "courtOrderInformation"
             ]
         },
@@ -134,7 +134,7 @@
                 "changeType",
                 "baseRegistrationNumber",
                 "registeringParty",
-                "baseDebtor"
+                "debtorName"
                 ]
         },
         {

--- a/src/registry_schemas/schemas/ppr/changeStatement.json
+++ b/src/registry_schemas/schemas/ppr/changeStatement.json
@@ -32,8 +32,8 @@
             "maxLength": 10,
             "description": "Optional draft document identifier if the Amendment is in a draft state and has not yet been registered. If included when creating the statement the draft will be deleted."
         },
-        "baseDebtor": {
-            "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/ppr/baseDebtor"
+        "debtorName": {
+            "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/ppr/debtorName"
         },
         "registeringParty": {
             "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/common/party"
@@ -112,7 +112,7 @@
                         "changeType",
                         "baseRegistrationNumber",
                         "registeringParty",
-                        "baseDebtor",
+                        "debtorName",
                         "addVehicleCollateral"
                     ]
                 },
@@ -121,7 +121,7 @@
                         "changeType",
                         "baseRegistrationNumber",
                         "registeringParty",
-                        "baseDebtor",
+                        "debtorName",
                         "addGeneralCollateral"
                     ]
                 },
@@ -147,7 +147,7 @@
                         "changeType",
                         "baseRegistrationNumber",
                         "registeringParty",
-                        "baseDebtor",
+                        "debtorName",
                         "deleteVehicleCollateral"
                     ]
                 },
@@ -156,7 +156,7 @@
                         "changeType",
                         "baseRegistrationNumber",
                         "registeringParty",
-                        "baseDebtor",
+                        "debtorName",
                         "deleteGeneralCollateral"
                     ]
                 },
@@ -165,7 +165,7 @@
                         "changeType",
                         "baseRegistrationNumber",
                         "registeringParty",
-                        "baseDebtor",
+                        "debtorName",
                         "deleteVehicleCollateral",
                         "deleteGeneralCollateral"
                     ]
@@ -192,7 +192,7 @@
                         "changeType",
                         "baseRegistrationNumber",
                         "registeringParty",
-                        "baseDebtor",
+                        "debtorName",
                         "deleteDebtors"
                     ]
                 },
@@ -219,7 +219,7 @@
                         "changeType",
                         "baseRegistrationNumber",
                         "registeringParty",
-                        "baseDebtor",
+                        "debtorName",
                         "deleteDebtors",
                         "addDebtors"
                     ]
@@ -248,7 +248,7 @@
                         "changeType",
                         "baseRegistrationNumber",
                         "registeringParty",
-                        "baseDebtor",
+                        "debtorName",
                         "deleteSecuredParties",
                         "addSecuredParties"
                     ]
@@ -277,7 +277,7 @@
                         "changeType",
                         "baseRegistrationNumber",
                         "registeringParty",
-                        "baseDebtor",
+                        "debtorName",
                         "addVehicleCollateral",
                         "deleteVehicleCollateral"
                     ]
@@ -287,7 +287,7 @@
                         "changeType",
                         "baseRegistrationNumber",
                         "registeringParty",
-                        "baseDebtor",
+                        "debtorName",
                         "addGeneralCollateral",
                         "deleteGeneralCollateral"
                     ]
@@ -297,7 +297,7 @@
                         "changeType",
                         "baseRegistrationNumber",
                         "registeringParty",
-                        "baseDebtor",
+                        "debtorName",
                         "addVehicleCollateral",
                         "deleteGeneralCollateral"
                     ]
@@ -307,7 +307,7 @@
                         "changeType",
                         "baseRegistrationNumber",
                         "registeringParty",
-                        "baseDebtor",
+                        "debtorName",
                         "addGeneralCollateral",
                         "deleteVehicleCollateral"
                     ]

--- a/src/registry_schemas/schemas/ppr/debtorName.json
+++ b/src/registry_schemas/schemas/ppr/debtorName.json
@@ -1,8 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/ppr/baseDebtor",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/ppr/debtorName",
     "type": "object",
-    "title": "The PPR Base Debtor Schema",
+    "title": "The PPR Debtor Name Schema",
     "definitions": {},
     "properties": {
        "businessName": {

--- a/src/registry_schemas/schemas/ppr/dischargeStatement.json
+++ b/src/registry_schemas/schemas/ppr/dischargeStatement.json
@@ -21,8 +21,8 @@
             "maxLength": 20,
             "description": "An optional client reference identifier associated with a change. Provided to facilitate client tracking of PPR activity."
         },
-        "baseDebtor": {
-            "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/ppr/baseDebtor"
+        "debtorName": {
+            "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/ppr/debtorName"
         },
         "registeringParty": {
             "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/common/party"
@@ -47,7 +47,7 @@
             "required": [
                 "baseRegistrationNumber",
                 "registeringParty",
-                "baseDebtor"
+                "debtorName"
             ]
         },
         {

--- a/src/registry_schemas/schemas/ppr/financingStatement.json
+++ b/src/registry_schemas/schemas/ppr/financingStatement.json
@@ -76,17 +76,17 @@
         },
         "trustIndenture": {
             "type": [ "boolean", "null" ],
-            "description": "Indicates if security interest is contained in a Trust Indenture. Required when the type is SA. Should be null otherwise."
+            "description": "Indicates if security interest is contained in a Trust Indenture. Required when the type is SA. Should be absent otherwise."
         },
         "lienAmount": {
             "type": [ "string", "null" ],
             "maxLength": 15,
-            "description": "The value of a lien. Required when the type is RL. Should be null otherwise."
+            "description": "The value of a lien. Required when the type is RL, otherwise it should be absent."
         },
         "surrenderDate": {
             "type": [ "string", "null" ],
             "format": "date-time",
-            "description": "The date the vehicle was or will be surrendered to the owner in the ISO 8601 format YYYY-MM-DDThh:mm:ssTZD. When provided it must be within the past 21 days or a later date. Required when the type is RL. Should be null otherwise."
+            "description": "The date the vehicle was or will be surrendered to the owner in the ISO 8601 format YYYY-MM-DDThh:mm:ssTZD. When provided it must be within the past 21 days or a later date. Required when the type is RL, otherwise it should be absent."
         },
         "baseRegistrationNumber": {
             "type": "string",
@@ -103,6 +103,11 @@
             "type": "string",
             "format": "date-time",
             "description": "Returned in search results detail information if applicable. The date and time in the ISO 8601 format YYYY-MM-DDThh:mm:ssTZD that the Financing Statement was discharged."
+        },
+        "otherTypeDescription": {
+            "type": [ "string", "null" ],
+            "maxLength": 70,
+            "description": "A text description when the crown charge type is other (OT). Required when the type is OT, otherwise should be absent."
         },
         "statusType": {
             "type": "string",

--- a/src/registry_schemas/schemas/ppr/renewalStatement.json
+++ b/src/registry_schemas/schemas/ppr/renewalStatement.json
@@ -21,8 +21,8 @@
             "maxLength": 20,
             "description": "An optional client reference identifier associated with a change. Provided to facilitate client tracking of PPR activity."
         },
-        "baseDebtor": {
-            "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/ppr/baseDebtor"
+        "debtorName": {
+            "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/ppr/debtorName"
         },
         "registeringParty": {
             "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/common/party"
@@ -61,7 +61,7 @@
             "required": [
                 "baseRegistrationNumber",
                 "registeringParty",
-                "baseDebtor",
+                "debtorName",
                 "lifeYears"
             ]
         },
@@ -69,7 +69,7 @@
             "required": [
                 "baseRegistrationNumber",
                 "registeringParty",
-                "baseDebtor",
+                "debtorName",
                 "expiryDate"
             ]
         },
@@ -77,7 +77,7 @@
             "required": [
                 "baseRegistrationNumber",
                 "registeringParty",
-                "baseDebtor",
+                "debtorName",
                 "courtOrderInformation"
             ]
         },

--- a/tests/unit/ppr/test_amendment_statement.py
+++ b/tests/unit/ppr/test_amendment_statement.py
@@ -58,7 +58,7 @@ def test_valid_amendment_removeindenture():
     """Assert that the schema is performing as expected for a amendment to remove a trust indenture."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
     statement['removeTrustIndenture'] = True
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['addTrustIndenture']
     del statement['deleteSecuredParties']
     del statement['addSecuredParties']
@@ -83,7 +83,7 @@ def test_valid_amendment_addindenture():
     """Assert that the schema is performing as expected for a amendment to add a trust indenture."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
     statement['addTrustIndenture'] = True
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['removeTrustIndenture']
     del statement['deleteSecuredParties']
     del statement['addSecuredParties']
@@ -107,7 +107,7 @@ def test_valid_amendment_addindenture():
 def test_valid_amendment_deletesecured():
     """Assert that the schema is performing as expected for a amendment to delete secured parties."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['removeTrustIndenture']
     del statement['addTrustIndenture']
     del statement['addSecuredParties']
@@ -131,7 +131,7 @@ def test_valid_amendment_deletesecured():
 def test_valid_amendment_addsecured():
     """Assert that the schema is performing as expected for a amendment to add secured parties."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['removeTrustIndenture']
     del statement['addTrustIndenture']
     del statement['deleteSecuredParties']
@@ -155,7 +155,7 @@ def test_valid_amendment_addsecured():
 def test_valid_amendment_deletedebtors():
     """Assert that the schema is performing as expected for a amendment to delete debtors."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['removeTrustIndenture']
     del statement['addTrustIndenture']
     del statement['addSecuredParties']
@@ -179,7 +179,7 @@ def test_valid_amendment_deletedebtors():
 def test_valid_amendment_adddebtors():
     """Assert that the schema is performing as expected for a amendment to add debtors."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['removeTrustIndenture']
     del statement['addTrustIndenture']
     del statement['addSecuredParties']
@@ -203,7 +203,7 @@ def test_valid_amendment_adddebtors():
 def test_valid_amendment_deletevehicles():
     """Assert that the schema is performing as expected for a amendment to delete vehicle collateral."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['removeTrustIndenture']
     del statement['addTrustIndenture']
     del statement['addSecuredParties']
@@ -227,7 +227,7 @@ def test_valid_amendment_deletevehicles():
 def test_valid_amendment_addvehicles():
     """Assert that the schema is performing as expected for a amendment to add vehicle collateral."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['removeTrustIndenture']
     del statement['addTrustIndenture']
     del statement['addSecuredParties']
@@ -251,7 +251,7 @@ def test_valid_amendment_addvehicles():
 def test_valid_amendment_deletegeneral():
     """Assert that the schema is performing as expected for a amendment to delete general collateral."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['removeTrustIndenture']
     del statement['addTrustIndenture']
     del statement['addSecuredParties']
@@ -275,7 +275,7 @@ def test_valid_amendment_deletegeneral():
 def test_valid_amendment_addgeneral():
     """Assert that the schema is performing as expected for a amendment to add general collateral."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['removeTrustIndenture']
     del statement['addTrustIndenture']
     del statement['addSecuredParties']
@@ -299,7 +299,7 @@ def test_valid_amendment_addgeneral():
 def test_valid_amendment_response():
     """Assert that the schema is performing as expected for an amendment response."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
 
     is_valid, errors = validate(statement, 'amendmentStatement', 'ppr')
 
@@ -329,7 +329,7 @@ def test_invalid_amendment_baseregnum():
 def test_invalid_amendment_clientref():
     """Assert that an invalid amendment statement fails - client reference number too long."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['clientReferenceId'] = 'RSXXXXXXXX00001234567'
 
     is_valid, errors = validate(statement, 'amendmentStatement', 'ppr')
@@ -345,7 +345,7 @@ def test_invalid_amendment_clientref():
 def test_invalid_amendment_doc_id():
     """Assert that an invalid amendment statement fails - document id too long."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['documentId'] = '00123456789'
 
     is_valid, errors = validate(statement, 'amendmentStatement', 'ppr')
@@ -361,7 +361,7 @@ def test_invalid_amendment_doc_id():
 def test_invalid_amendment_changetype():
     """Assert that an invalid amendment statement fails - change type is invalid."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['changeType'] = 'XX'
 
     is_valid, errors = validate(statement, 'amendmentStatement', 'ppr')
@@ -377,7 +377,7 @@ def test_invalid_amendment_changetype():
 def test_invalid_amendment_courtorder():
     """Assert that an invalid amendment statement fails - court order court name is missing."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['courtOrderInformation']['courtName']
 
     is_valid, errors = validate(statement, 'amendmentStatement', 'ppr')
@@ -393,7 +393,7 @@ def test_invalid_amendment_courtorder():
 def test_invalid_amendment_timestamp():
     """Assert that an invalid amendment statement fails - create timestamp format is invalid."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['createDateTime'] = 'XXXXXXXXXXXX'
 
     is_valid, errors = validate(statement, 'amendmentStatement', 'ppr')
@@ -409,7 +409,7 @@ def test_invalid_amendment_timestamp():
 def test_invalid_amendment_regnum():
     """Assert that an invalid amendment statement fails - registration number too long."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['amendmentRegistrationNumber'] = 'D000012345678'
 
     is_valid, errors = validate(statement, 'amendmentStatement', 'ppr')
@@ -425,7 +425,7 @@ def test_invalid_amendment_regnum():
 def test_invalid_amendment_delete_debtor_name():
     """Assert that an invalid amendment statement fails - delete debtor name is missing."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['deleteDebtors'][0]['businessName']
 
     is_valid, errors = validate(statement, 'amendmentStatement', 'ppr')
@@ -441,7 +441,7 @@ def test_invalid_amendment_delete_debtor_name():
 def test_invalid_amendment_add_debtor_address():
     """Assert that an invalid amendment statement fails - add debtor address is missing."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['addDebtors'][0]['address']
     del statement['addDebtors'][0]['partyId']
 
@@ -458,7 +458,7 @@ def test_invalid_amendment_add_debtor_address():
 def test_invalid_amendment_delete_secured_name():
     """Assert that an invalid amendment statement fails - delete secured party name is missing."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['deleteSecuredParties'][0]['businessName']
 
     is_valid, errors = validate(statement, 'amendmentStatement', 'ppr')
@@ -474,7 +474,7 @@ def test_invalid_amendment_delete_secured_name():
 def test_invalid_amendment_add_secured_address():
     """Assert that an invalid amendment statement fails - add secured party address is missing."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['addSecuredParties'][0]['address']
     del statement['addSecuredParties'][0]['partyId']
 
@@ -491,7 +491,7 @@ def test_invalid_amendment_add_secured_address():
 def test_invalid_amendment_delete_vehicle_type():
     """Assert that an invalid amendment statement fails - delete vehicle collateral type is missing."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['deleteVehicleCollateral'][0]['type']
 
     is_valid, errors = validate(statement, 'amendmentStatement', 'ppr')
@@ -507,7 +507,7 @@ def test_invalid_amendment_delete_vehicle_type():
 def test_invalid_amendment_add_vehicle_serial():
     """Assert that an invalid amendment statement fails - add vehicle collateral serial number is missing."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['addVehicleCollateral'][0]['serialNumber']
 
     is_valid, errors = validate(statement, 'amendmentStatement', 'ppr')
@@ -523,7 +523,7 @@ def test_invalid_amendment_add_vehicle_serial():
 def test_invalid_amendment_delete_general_desc():
     """Assert that an invalid amendment statement fails - delete general collateral description is missing."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['deleteGeneralCollateral'][0]['description']
 
     is_valid, errors = validate(statement, 'amendmentStatement', 'ppr')
@@ -539,7 +539,7 @@ def test_invalid_amendment_delete_general_desc():
 def test_invalid_amendment_add_general_desc():
     """Assert that an invalid amendment statement fails - add general collateral description is missing."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['addGeneralCollateral'][0]['description']
 
     is_valid, errors = validate(statement, 'amendmentStatement', 'ppr')
@@ -558,7 +558,7 @@ def test_invalid_amendment_missing_debtor_first():
     del statement['createDateTime']
     del statement['amendmentRegistrationNumber']
     del statement['payment']
-    del statement['baseDebtor']['businessName']
+    del statement['debtorName']['businessName']
 
     is_valid, errors = validate(statement, 'amendmentStatement', 'ppr')
 
@@ -573,7 +573,7 @@ def test_invalid_amendment_missing_debtor_first():
 def test_invalid_amendment_missing_regparty_address():
     """Assert that an invalid amendment statement fails - registering party address is missing."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['registeringParty']['address']
 
     is_valid, errors = validate(statement, 'amendmentStatement', 'ppr')
@@ -589,7 +589,7 @@ def test_invalid_amendment_missing_regparty_address():
 def test_invalid_amendment_missing_basereg():
     """Assert that an invalid amendment statement fails - base registration number is missing."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['baseRegistrationNumber']
 
     is_valid, errors = validate(statement, 'amendmentStatement', 'ppr')
@@ -605,7 +605,7 @@ def test_invalid_amendment_missing_basereg():
 def test_invalid_amendment_missing_regparty():
     """Assert that an invalid amendment statement fails - registering party is missing."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['registeringParty']
 
     is_valid, errors = validate(statement, 'amendmentStatement', 'ppr')
@@ -621,7 +621,7 @@ def test_invalid_amendment_missing_regparty():
 def test_invalid_amendment_missing_changetype():
     """Assert that an invalid amendment statement fails - change type missing."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['changeType']
 
     is_valid, errors = validate(statement, 'amendmentStatement', 'ppr')
@@ -637,7 +637,7 @@ def test_invalid_amendment_missing_changetype():
 def test_invalid_amendment_co_missing_info():
     """Assert that an invalid amendment statement fails - CO change type missing court order information."""
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['changeType']
     del statement['courtOrderInformation']
 

--- a/tests/unit/ppr/test_change_statement.py
+++ b/tests/unit/ppr/test_change_statement.py
@@ -216,7 +216,7 @@ def test_valid_change_request_su_vehicle():
     """Assert that the schema is performing as expected for a subsitution of vehicle collateral change request."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'SU'
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['addSecuredParties']
     del statement['deleteSecuredParties']
     del statement['deleteDebtors']
@@ -238,7 +238,7 @@ def test_valid_change_request_su_general():
     """Assert that the schema is performing as expected for a subsitution of general collateral change request."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
     statement['changeType'] = 'SU'
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['addSecuredParties']
     del statement['deleteSecuredParties']
     del statement['deleteDebtors']
@@ -268,7 +268,7 @@ def test_valid_change_request_su_general():
 def test_valid_change_response():
     """Assert that the schema is performing as expected for an change response."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
 
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')
 
@@ -472,7 +472,7 @@ def test_invalid_change_baseregnum():
 def test_invalid_change_clientref():
     """Assert that an invalid change statement fails - client reference number too long."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['clientReferenceId'] = 'RSXXXXXXXX00001234567'
 
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')
@@ -488,7 +488,7 @@ def test_invalid_change_clientref():
 def test_invalid_change_doc_id():
     """Assert that an invalid change statement fails - document id too long."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['documentId'] = '00123456789'
 
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')
@@ -504,7 +504,7 @@ def test_invalid_change_doc_id():
 def test_invalid_change_changetype():
     """Assert that an invalid change statement fails - change type is invalid."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['changeType'] = 'XX'
 
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')
@@ -520,7 +520,7 @@ def test_invalid_change_changetype():
 def test_invalid_change_timestamp():
     """Assert that an invalid change statement fails - create timestamp format is invalid."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['createDateTime'] = 'XXXXXXXXXXXX'
 
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')
@@ -536,7 +536,7 @@ def test_invalid_change_timestamp():
 def test_invalid_change_regnum():
     """Assert that an invalid change statement fails - registration number too long."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['changeRegistrationNumber'] = 'D000012345678'
 
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')
@@ -552,7 +552,7 @@ def test_invalid_change_regnum():
 def test_invalid_change_delete_debtor_name():
     """Assert that an invalid change statement fails - delete debtor name is missing."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['deleteDebtors'][0]['businessName']
 
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')
@@ -568,7 +568,7 @@ def test_invalid_change_delete_debtor_name():
 def test_invalid_change_add_debtor_address():
     """Assert that an invalid change statement fails - add debtor address is missing."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['addDebtors'][0]['address']
     del statement['addDebtors'][0]['partyId']
 
@@ -585,7 +585,7 @@ def test_invalid_change_add_debtor_address():
 def test_invalid_change_delete_secured_name():
     """Assert that an invalid change statement fails - delete secured party name is missing."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['deleteSecuredParties'][0]['businessName']
 
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')
@@ -601,7 +601,7 @@ def test_invalid_change_delete_secured_name():
 def test_invalid_change_add_secured_address():
     """Assert that an invalid change statement fails - add secured party address is missing."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['addSecuredParties'][0]['address']
     del statement['addSecuredParties'][0]['partyId']
 
@@ -618,7 +618,7 @@ def test_invalid_change_add_secured_address():
 def test_invalid_change_delete_vehicle_type():
     """Assert that an invalid change statement fails - delete vehicle collateral type is missing."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['deleteVehicleCollateral'][0]['type']
 
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')
@@ -634,7 +634,7 @@ def test_invalid_change_delete_vehicle_type():
 def test_invalid_change_add_vehicle_serial():
     """Assert that an invalid change statement fails - add vehicle collateral serial number is missing."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['addVehicleCollateral'][0]['serialNumber']
 
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')
@@ -650,7 +650,7 @@ def test_invalid_change_add_vehicle_serial():
 def test_invalid_change_delete_general_desc():
     """Assert that an invalid change statement fails - delete general collateral description is missing."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['deleteGeneralCollateral'][0]['description']
 
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')
@@ -666,7 +666,7 @@ def test_invalid_change_delete_general_desc():
 def test_invalid_change_add_general_desc():
     """Assert that an invalid change statement fails - add general collateral description is missing."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['addGeneralCollateral'][0]['description']
 
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')
@@ -685,7 +685,7 @@ def test_invalid_change_missing_debtor_first():
     del statement['createDateTime']
     del statement['changeRegistrationNumber']
     del statement['payment']
-    del statement['baseDebtor']['businessName']
+    del statement['debtorName']['businessName']
 
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')
 
@@ -700,7 +700,7 @@ def test_invalid_change_missing_debtor_first():
 def test_invalid_change_missing_regparty_address():
     """Assert that an invalid change statement fails - registering party address is missing."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['registeringParty']['address']
 
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')
@@ -716,7 +716,7 @@ def test_invalid_change_missing_regparty_address():
 def test_invalid_change_missing_basereg():
     """Assert that an invalid change statement fails - base registration number is missing."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['baseRegistrationNumber']
 
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')
@@ -732,7 +732,7 @@ def test_invalid_change_missing_basereg():
 def test_invalid_change_missing_regparty():
     """Assert that an invalid change statement fails - registering party is missing."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['registeringParty']
 
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')
@@ -748,7 +748,7 @@ def test_invalid_change_missing_regparty():
 def test_invalid_change_missing_changetype():
     """Assert that an invalid change statement fails - change type missing."""
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['changeType']
 
     is_valid, errors = validate(statement, 'changeStatement', 'ppr')

--- a/tests/unit/ppr/test_debtor_name.py
+++ b/tests/unit/ppr/test_debtor_name.py
@@ -15,12 +15,12 @@
 import copy
 
 from registry_schemas import validate
-from registry_schemas.example_data.ppr import BASE_DEBTOR
+from registry_schemas.example_data.ppr import DEBTOR_NAME
 
 
 def test_valid_debtor_person():
     """Assert that the schema is performing as expected for an individual debtor."""
-    is_valid, errors = validate(BASE_DEBTOR, 'baseDebtor', 'ppr')
+    is_valid, errors = validate(DEBTOR_NAME, 'debtorName', 'ppr')
 
     if errors:
         for err in errors:
@@ -32,10 +32,10 @@ def test_valid_debtor_person():
 
 def test_valid_debtor_business():
     """Assert that the schema is performing as expected for a business debtor."""
-    debtor = copy.deepcopy(BASE_DEBTOR)
+    debtor = copy.deepcopy(DEBTOR_NAME)
     debtor['businessName'] = 'BUSINESS NAME DEBTOR INC.'
     del debtor['personName']
-    is_valid, errors = validate(debtor, 'baseDebtor', 'ppr')
+    is_valid, errors = validate(debtor, 'debtorName', 'ppr')
 
     if errors:
         for err in errors:
@@ -47,10 +47,10 @@ def test_valid_debtor_business():
 
 def test_invalid_debtor_missing_firstname():
     """Assert that an invalid debtor fails - person first name is missing."""
-    debtor = copy.deepcopy(BASE_DEBTOR)
+    debtor = copy.deepcopy(DEBTOR_NAME)
     del debtor['personName']['first']
 
-    is_valid, errors = validate(debtor, 'baseDebtor', 'ppr')
+    is_valid, errors = validate(debtor, 'debtorName', 'ppr')
 
     if errors:
         for err in errors:
@@ -62,10 +62,10 @@ def test_invalid_debtor_missing_firstname():
 
 def test_invalid_debtor_missing_lastname():
     """Assert that an invalid debtor fails - person last name is missing."""
-    debtor = copy.deepcopy(BASE_DEBTOR)
+    debtor = copy.deepcopy(DEBTOR_NAME)
     del debtor['personName']['last']
 
-    is_valid, errors = validate(debtor, 'baseDebtor', 'ppr')
+    is_valid, errors = validate(debtor, 'debtorName', 'ppr')
 
     if errors:
         for err in errors:
@@ -77,10 +77,10 @@ def test_invalid_debtor_missing_lastname():
 
 def test_invalid_debtor_missing_debtor():
     """Assert that an invalid debtor fails - debtor name is missing."""
-    debtor = copy.deepcopy(BASE_DEBTOR)
+    debtor = copy.deepcopy(DEBTOR_NAME)
     del debtor['personName']
 
-    is_valid, errors = validate(debtor, 'baseDebtor', 'ppr')
+    is_valid, errors = validate(debtor, 'debtorName', 'ppr')
 
     if errors:
         for err in errors:

--- a/tests/unit/ppr/test_discharge_statement.py
+++ b/tests/unit/ppr/test_discharge_statement.py
@@ -38,7 +38,7 @@ def test_valid_discharge_request():
 def test_valid_discharge_response():
     """Assert that the schema is performing as expected for a discharge response."""
     statement = copy.deepcopy(DISCHARGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
 
     is_valid, errors = validate(statement, 'dischargeStatement', 'ppr')
 
@@ -53,7 +53,7 @@ def test_valid_discharge_response():
 def test_invalid_discharge_baseregnum():
     """Assert that an invalid discharge statement fails - base registration number too long."""
     statement = copy.deepcopy(DISCHARGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['baseRegistrationNumber'] = 'B0000123456789'
 
     is_valid, errors = validate(statement, 'dischargeStatement', 'ppr')
@@ -69,7 +69,7 @@ def test_invalid_discharge_baseregnum():
 def test_invalid_discharge_clientref():
     """Assert that an invalid discharge statement fails - client reference number too long."""
     statement = copy.deepcopy(DISCHARGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['clientReferenceId'] = 'RSXXXXXXXX00001234567'
 
     is_valid, errors = validate(statement, 'dischargeStatement', 'ppr')
@@ -85,7 +85,7 @@ def test_invalid_discharge_clientref():
 def test_invalid_discharge_timestamp():
     """Assert that an invalid discharge statement fails - create timestamp format is invalid."""
     statement = copy.deepcopy(DISCHARGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['createDateTime'] = 'XXXXXXXXXXXX'
 
     is_valid, errors = validate(statement, 'dischargeStatement', 'ppr')
@@ -101,7 +101,7 @@ def test_invalid_discharge_timestamp():
 def test_invalid_discharge_regnum():
     """Assert that an invalid discharge statement fails - registration number too long."""
     statement = copy.deepcopy(DISCHARGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['dischargeRegistrationNumber'] = 'D000012345678'
 
     is_valid, errors = validate(statement, 'dischargeStatement', 'ppr')
@@ -120,7 +120,7 @@ def test_invalid_discharge_missing_debtor_first():
     del statement['createDateTime']
     del statement['dischargeRegistrationNumber']
     del statement['payment']
-    del statement['baseDebtor']['businessName']
+    del statement['debtorName']['businessName']
 
     is_valid, errors = validate(statement, 'dischargeStatement', 'ppr')
 
@@ -135,7 +135,7 @@ def test_invalid_discharge_missing_debtor_first():
 def test_invalid_discharge_missing_regparty_address():
     """Assert that an invalid discharge statement fails - registering party address is missing."""
     statement = copy.deepcopy(DISCHARGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['registeringParty']['address']
 
     is_valid, errors = validate(statement, 'dischargeStatement', 'ppr')
@@ -151,7 +151,7 @@ def test_invalid_discharge_missing_regparty_address():
 def test_invalid_discharge_missing_basereg():
     """Assert that an invalid discharge statement fails - base registration number is missing."""
     statement = copy.deepcopy(DISCHARGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['baseRegistrationNumber']
 
     is_valid, errors = validate(statement, 'dischargeStatement', 'ppr')
@@ -167,7 +167,7 @@ def test_invalid_discharge_missing_basereg():
 def test_invalid_discharge_missing_regparty():
     """Assert that an invalid discharge statement fails - registering party is missing."""
     statement = copy.deepcopy(DISCHARGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['registeringParty']
 
     is_valid, errors = validate(statement, 'dischargeStatement', 'ppr')
@@ -183,7 +183,7 @@ def test_invalid_discharge_missing_regparty():
 def test_invalid_discharge_missing_debtor():
     """Assert that an invalid discharge statement fails - base debtor and statement reg number are missing."""
     statement = copy.deepcopy(DISCHARGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['createDateTime']
     del statement['dischargeRegistrationNumber']
     del statement['payment']

--- a/tests/unit/ppr/test_financing_statement.py
+++ b/tests/unit/ppr/test_financing_statement.py
@@ -60,6 +60,11 @@ TEST_DATA_REG_TYPE = [
     ('WL', True),
     ('XX', False),
 ]
+# testdata pattern is ({other type description}, {is valid})
+TEST_DATA_OT = [
+    ('0123456789012345678901234567890123456789012345678901234567890123456789', True),
+    ('01234567890123456789012345678901234567890123456789012345678901234567890', False),
+]
 
 
 @pytest.mark.parametrize('registration_type, valid', TEST_DATA_REG_TYPE)
@@ -76,6 +81,32 @@ def test_financing_regtype(registration_type, valid):
     elif registration_type != 'RL':
         del statement['lienAmount']
         del statement['surrenderDate']
+
+    is_valid, errors = validate(statement, 'financingStatement', 'ppr')
+
+    if errors:
+        for err in errors:
+            print(err.message)
+
+    if valid:
+        assert is_valid
+    else:
+        assert not is_valid
+
+
+@pytest.mark.parametrize('other_description, valid', TEST_DATA_OT)
+def test_financing_ot(other_description, valid):
+    """Assert the validation of OT type otherTypeDescription."""
+    statement = copy.deepcopy(FINANCING_STATEMENT)
+    statement['type'] = 'OT'
+    statement['otherTypeDescription'] = other_description
+    del statement['createDateTime']
+    del statement['baseRegistrationNumber']
+    del statement['payment']
+    del statement['lifeInfinite']
+    del statement['trustIndenture']
+    del statement['lienAmount']
+    del statement['surrenderDate']
 
     is_valid, errors = validate(statement, 'financingStatement', 'ppr')
 

--- a/tests/unit/ppr/test_financing_statement_history.py
+++ b/tests/unit/ppr/test_financing_statement_history.py
@@ -78,7 +78,7 @@ def test_valid_financing_history_change():
     del history[0]['changes'][3]
     del history[0]['changes'][2]
     del history[0]['changes'][1]
-    del statement['baseDebtor']
+    del statement['debtorName']
     history[0]['changes'][0] = statement
 
     is_valid, errors = validate(history, 'financingStatementHistory', 'ppr')
@@ -95,7 +95,7 @@ def test_valid_financing_history_renewal():
     """Assert that the schema is performing as expected for a financing history list with 1 renewal statement."""
     history = copy.deepcopy(FINANCING_STATEMENT_HISTORY)
     statement = copy.deepcopy(RENEWAL_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del history[0]['changes'][3]
     del history[0]['changes'][2]
     del history[0]['changes'][1]
@@ -115,7 +115,7 @@ def test_valid_financing_history_discharge():
     """Assert that the schema is performing as expected for a financing history list with 1 discharge statement."""
     history = copy.deepcopy(FINANCING_STATEMENT_HISTORY)
     statement = copy.deepcopy(DISCHARGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del history[0]['changes'][3]
     del history[0]['changes'][2]
     del history[0]['changes'][1]
@@ -135,7 +135,7 @@ def test_valid_financing_history_changes():
     """Assert that the schema is performing as expected for a financing history list with 2 change statements."""
     history = copy.deepcopy(FINANCING_STATEMENT_HISTORY)
     statement = copy.deepcopy(CHANGE_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     history[0]['changes'][3] = statement
 
     is_valid, errors = validate(history, 'financingStatementHistory', 'ppr')
@@ -152,7 +152,7 @@ def test_valid_financing_history_amendments():
     """Assert that the schema is performing as expected for a financing history list with 2 amendment statements."""
     history = copy.deepcopy(FINANCING_STATEMENT_HISTORY)
     statement = copy.deepcopy(AMENDMENT_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     history[0]['changes'][3] = statement
 
     is_valid, errors = validate(history, 'financingStatementHistory', 'ppr')
@@ -169,7 +169,7 @@ def test_valid_financing_history_renewals():
     """Assert that the schema is performing as expected for a financing history list with 2 renewal statements."""
     history = copy.deepcopy(FINANCING_STATEMENT_HISTORY)
     statement = copy.deepcopy(RENEWAL_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     history[0]['changes'][3] = statement
 
     is_valid, errors = validate(history, 'financingStatementHistory', 'ppr')

--- a/tests/unit/ppr/test_renewal_statement.py
+++ b/tests/unit/ppr/test_renewal_statement.py
@@ -57,7 +57,7 @@ def test_valid_renewal_rl_request():
 def test_valid_renewal_response():
     """Assert that the schema is performing as expected for an renewal response."""
     statement = copy.deepcopy(RENEWAL_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
 
     is_valid, errors = validate(statement, 'renewalStatement', 'ppr')
 
@@ -72,7 +72,7 @@ def test_valid_renewal_response():
 def test_invalid_renewal_baseregnum():
     """Assert that an invalid renewal statement fails - base registration number too long."""
     statement = copy.deepcopy(RENEWAL_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['baseRegistrationNumber'] = 'B0000123456789'
 
     is_valid, errors = validate(statement, 'renewalStatement', 'ppr')
@@ -88,7 +88,7 @@ def test_invalid_renewal_baseregnum():
 def test_invalid_renewal_clientref():
     """Assert that an invalid renewal statement fails - client reference number too long."""
     statement = copy.deepcopy(RENEWAL_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['clientReferenceId'] = 'RSXXXXXXXX00001234567'
 
     is_valid, errors = validate(statement, 'renewalStatement', 'ppr')
@@ -104,7 +104,7 @@ def test_invalid_renewal_clientref():
 def test_invalid_renewal_courtorder():
     """Assert that an invalid renewal statement fails - court order court name is missing."""
     statement = copy.deepcopy(RENEWAL_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['courtOrderInformation']['courtName']
 
     is_valid, errors = validate(statement, 'renewalStatement', 'ppr')
@@ -120,7 +120,7 @@ def test_invalid_renewal_courtorder():
 def test_invalid_renewal_expiry():
     """Assert that an invalid renewal statement fails - expiry date format is invalid."""
     statement = copy.deepcopy(RENEWAL_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['expiryDate'] = 'XXXXXXXX'
 
     is_valid, errors = validate(statement, 'renewalStatement', 'ppr')
@@ -136,7 +136,7 @@ def test_invalid_renewal_expiry():
 def test_invalid_renewal_timestamp():
     """Assert that an invalid renewal statement fails - create timestamp format is invalid."""
     statement = copy.deepcopy(RENEWAL_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['createDateTime'] = 'XXXXXXXXXXXX'
 
     is_valid, errors = validate(statement, 'renewalStatement', 'ppr')
@@ -152,7 +152,7 @@ def test_invalid_renewal_timestamp():
 def test_invalid_renewal_regnum():
     """Assert that an invalid renewal statement fails - registration number too long."""
     statement = copy.deepcopy(RENEWAL_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     statement['renewalRegistrationNumber'] = 'D000012345678'
 
     is_valid, errors = validate(statement, 'renewalStatement', 'ppr')
@@ -171,7 +171,7 @@ def test_invalid_renewal_missing_debtor_first():
     del statement['createDateTime']
     del statement['renewalRegistrationNumber']
     del statement['payment']
-    del statement['baseDebtor']['businessName']
+    del statement['debtorName']['businessName']
 
     is_valid, errors = validate(statement, 'renewalStatement', 'ppr')
 
@@ -186,7 +186,7 @@ def test_invalid_renewal_missing_debtor_first():
 def test_invalid_renewal_missing_regparty_address():
     """Assert that an invalid renewal statement fails - registering party address is missing."""
     statement = copy.deepcopy(RENEWAL_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['registeringParty']['address']
 
     is_valid, errors = validate(statement, 'renewalStatement', 'ppr')
@@ -202,7 +202,7 @@ def test_invalid_renewal_missing_regparty_address():
 def test_invalid_renewal_missing_basereg():
     """Assert that an invalid renewal statement fails - base registration number is missing."""
     statement = copy.deepcopy(RENEWAL_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['baseRegistrationNumber']
 
     is_valid, errors = validate(statement, 'renewalStatement', 'ppr')
@@ -218,7 +218,7 @@ def test_invalid_renewal_missing_basereg():
 def test_invalid_renewal_missing_regparty():
     """Assert that an invalid renewal statement fails - registering party is missing."""
     statement = copy.deepcopy(RENEWAL_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['registeringParty']
 
     is_valid, errors = validate(statement, 'renewalStatement', 'ppr')
@@ -234,7 +234,7 @@ def test_invalid_renewal_missing_regparty():
 def test_invalid_renewal_missing_debtor():
     """Assert that an invalid renewal statement fails - base debtor and statement reg number are missing."""
     statement = copy.deepcopy(RENEWAL_STATEMENT)
-    del statement['baseDebtor']
+    del statement['debtorName']
     del statement['createDateTime']
     del statement['renewalRegistrationNumber']
     del statement['payment']


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#8453

*Description of changes:*
- Add financingStatement.otherTypeDescription for crown charge type OT.
- Refactor basedDebtorName to debtorName (remove "base debtor" from the API). 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the registry-schemas license (Apache 2.0).
