### PR TITLE
8804 PPR schema add 3 financing statement types

### DIFF
--- a/src/registry_schemas/schemas/ppr/financingStatement.json
+++ b/src/registry_schemas/schemas/ppr/financingStatement.json
@@ -9,7 +9,7 @@
             "type": "string",
             "maxLength": 2,
             "enum": ["SA", "RL", "FR", "LT", "MH", "SG", "FL", "FA", "FS", "MR", "CC", "CT", "DP", "ET", "FO", "FT", "HR", "IP", "LO", "MI", "OT"
-                , "PG", "PS", "IT", "RA", "SS", "TL", "HN", "ML", "MN", "PN", "WL", "TF", "TA", "TG", "TM"],
+                , "PG", "PS", "IT", "RA", "SS", "TL", "HN", "ML", "MN", "PN", "WL", "TF", "TA", "TG", "TM", "MD", "PT", "SC"],
             "description": "Specifies the type of Financing Statement. Includes all legacy registration types."
         },
         "clientReferenceId": {

--- a/src/registry_schemas/utils.py
+++ b/src/registry_schemas/utils.py
@@ -38,7 +38,7 @@ def _load_json_schema(filename: str):
     relative_path = path.join('schemas', filename)
     absolute_path = path.join(path.dirname(__file__), relative_path)
 
-    with open(absolute_path, 'r') as schema_file:
+    with open(absolute_path, 'r', encoding='UTF-8') as schema_file:
         schema = json.loads(schema_file.read())
 
         return schema
@@ -57,7 +57,7 @@ def get_schema_store(validate_schema: bool = False, schema_search_path: str = No
             for fname in filenames:
                 fpath = path.join(dirpath, fname)
                 if fpath[-5:] == '.json':
-                    with open(fpath, 'r') as schema_fd:
+                    with open(fpath, 'r', encoding='UTF-8') as schema_fd:
                         schema = json.load(schema_fd)
                         if '$id' in schema:
                             schemastore[schema['$id']] = schema

--- a/tests/unit/ppr/test_financing_statement.py
+++ b/tests/unit/ppr/test_financing_statement.py
@@ -58,6 +58,9 @@ TEST_DATA_REG_TYPE = [
     ('TL', True),
     ('TM', True),
     ('WL', True),
+    ('MD', True),
+    ('PT', True),
+    ('SC', True),
     ('XX', False),
 ]
 # testdata pattern is ({other type description}, {is valid})


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#8804

*Description of changes:*
PPR schema add 3 financing statement types.
- Add new registration type MD Mineral Land Tax Act
- Add new registration type PT Property Transfer Tax Act
- Add new registration type SC School Act

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the registry-schemas license (Apache 2.0).
