### PR TITLE
PPR Remove length limit on general collateral description.

### DIFF
--- a/src/registry_schemas/schemas/ppr/generalCollateral.json
+++ b/src/registry_schemas/schemas/ppr/generalCollateral.json
@@ -8,19 +8,16 @@
         "description": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 4000,
             "description": "The Financing Statement description of the general collateral and proceeds being claimed in accordance with the legislative requirements."
         },
         "descriptionAdd": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 4000,
             "description": "The Change or Amendment description of the general collateral and proceeds added to the Financing Statement. Included in the search consolidated view of a Financing Statement."
         },
         "descriptionDelete": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 4000,
             "description": "The Change or Amendment description of the general collateral and proceeds added to the Financing Statement. Included in the search consolidated view of a Financing Statement."
         },
         "addedDateTime": {


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#10266

*Description of changes:*
PPR generalCollateral schema remove 4000 character length limit on description.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the registry-schemas license (Apache 2.0).
