### PR TITLE
11471 Add new enums to financialStatement.json

### DIFF
--- a/src/registry_schemas/schemas/ppr/financingStatement.json
+++ b/src/registry_schemas/schemas/ppr/financingStatement.json
@@ -9,7 +9,7 @@
             "type": "string",
             "maxLength": 2,
             "enum": ["SA", "RL", "FR", "LT", "MH", "SG", "FL", "FA", "FS", "MR", "CC", "CT", "DP", "ET", "FO", "FT", "HR", "IP", "LO", "MI", "OT"
-                , "PG", "PS", "IT", "RA", "SS", "TL", "HN", "ML", "MN", "PN", "WL", "TF", "TA", "TG", "TM", "MD", "PT", "SC"],
+                , "PG", "PS", "IT", "RA", "SS", "TL", "HN", "ML", "MN", "PN", "WL", "TF", "TA", "TG", "TM", "TO", "SV", "MD", "PT", "SC"],
             "description": "Specifies the type of Financing Statement. Includes all legacy registration types."
         },
         "clientReferenceId": {

--- a/tests/unit/ppr/test_financing_statement.py
+++ b/tests/unit/ppr/test_financing_statement.py
@@ -61,6 +61,8 @@ TEST_DATA_REG_TYPE = [
     ('MD', True),
     ('PT', True),
     ('SC', True),
+    ('TO', True),
+    ('SV', True),
     ('XX', False),
 ]
 # testdata pattern is ({other type description}, {is valid})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#11471

_Description of changes:_
Add new registration types TO, SV to enums

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the registry-schemas license (Apache 2.0).
