### PR TITLE
Latest mhr api registration schema updates.

### DIFF
--- a/src/registry_schemas/example_data/mhr/schema_data.py
+++ b/src/registry_schemas/example_data/mhr/schema_data.py
@@ -133,10 +133,10 @@ OWNER = {
     'street': '3122B LYNNLARK PLACE',
     'city': 'VICTORIA',
     'region': 'BC',
-    'postalCode': ' ',
+    'postalCode': 'V8S 4I6',
     'country': 'CA'
   },
-  'type': 'SO',
+  'type': 'SOLE',
   'phoneNumber': '6041234567',
   'status': 'EXEMPT',
   'suffix': 'EXECUTOR OF THE WILL OF JUDITH ANN JANZEN, DECEASED'
@@ -154,13 +154,13 @@ OWNER_GROUP = {
         'street': '3122B LYNNLARK PLACE',
         'city': 'VICTORIA',
         'region': 'BC',
-        'postalCode': ' ',
+        'postalCode': 'V8S 4I6',
         'country': 'CA'
       },
       'phoneNumber': '6041234567'
     }
   ],
-  'type': 'TC',
+  'type': 'COMMON',
   'interest': 'UNDIVIDED 4/5',
   'interestNumerator': 4,
   'status': 'ACTIVE',
@@ -180,9 +180,11 @@ PERSON_NAME = {
 
 REGISTRATION = {
   'mhrNumber': '001234',
+  'documentId': '42800656',
   'status': 'ACTIVE',
   'clientReferenceId': 'EX-MH001234',
   'declaredValue': '120000.00',
+  'attentionReference': 'GWB14768.100',
   'submittingParty': {
     'businessName': 'ABC SEARCHING COMPANY',
     'address': {
@@ -215,7 +217,7 @@ REGISTRATION = {
           'phoneNumber': '6041234567'
         }
       ],
-      'type': 'TC',
+      'type': 'COMMON',
       'interest': 'UNDIVIDED 4/5',
       'interestNumerator': 4,
       'status': 'ACTIVE',
@@ -238,7 +240,7 @@ REGISTRATION = {
           'phoneNumber': '6041234567'
         }
       ],
-      'type': 'TC',
+      'type': 'COMMON',
       'interest': 'UNDIVIDED 1/5',
       'interestNumerator': 1,
       'status': 'ACTIVE',
@@ -354,25 +356,57 @@ SEARCH_DETAIL_RESULT = {
   'details': [
     {
       'mhrNumber': '001234',
+      'documentId': '42800656',
       'status': 'ACTIVE',
       'clientReferenceId': 'EX-MH001234',
       'declaredValue': '120000.00',
-      'owners': [
+      'ownerGroups': [
         {
-          'individualName': {
-            'first': 'James',
-            'last': 'Smith'
-          },
-          'address': {
-            'street': '3122B LYNNLARK PLACE',
-            'city': 'VICTORIA',
-            'region': 'BC',
-            'postalCode': ' ',
-            'country': 'CA'
-          },
-          'type': 'SO',
-          'phoneNumber': '2504771234',
-          'status': 'ACTIVE'
+          'groupId': 1,
+          'owners': [
+            {
+              'individualName': {
+                'first': 'Jane',
+                'last': 'Smith'
+              },
+              'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+              },
+              'phoneNumber': '6041234567'
+            }
+          ],
+          'type': 'COMMON',
+          'interest': 'UNDIVIDED 4/5',
+          'interestNumerator': 4,
+          'status': 'ACTIVE',
+          'tenancySpecified': True
+        }, {
+          'groupId': 2,
+          'owners': [
+            {
+              'individualName': {
+                'first': 'James',
+                'last': 'Smith'
+              },
+              'address': {
+                'street': '3122B LYNNLARK PLACE',
+                'city': 'VICTORIA',
+                'region': 'BC',
+                'postalCode': ' ',
+                'country': 'CA'
+              },
+              'phoneNumber': '6041234567'
+            }
+          ],
+          'type': 'COMMON',
+          'interest': 'UNDIVIDED 1/5',
+          'interestNumerator': 1,
+          'status': 'ACTIVE',
+          'tenancySpecified': True
         }
       ],
       'location': {

--- a/src/registry_schemas/schemas/common/party.json
+++ b/src/registry_schemas/schemas/common/party.json
@@ -41,14 +41,14 @@
         "phoneNumber": {
             "type": "string",
             "minLength": 10,
-            "maxLength": 20,
+            "maxLength": 10,
             "description": "Free form text with area code for the party contact phone number without an extension value.",
             "example": "2504772734"
         },
         "phoneExtension": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 10,
+            "maxLength": 5,
             "description": "The contact phone number extension value.",
             "example": "546"
         }

--- a/src/registry_schemas/schemas/mhr/owner.json
+++ b/src/registry_schemas/schemas/mhr/owner.json
@@ -19,8 +19,8 @@
         "type": {
             "type": "string",
             "maxLength": 20,
-            "enum": ["JT", "SO", "TC"],
-            "description": "The type of owner."
+            "enum": ["JOINT", "SOLE", "COMMON", "JT", "SO", "TC"],
+            "description": "The type of owner group. JOINT - joint tenancy; SOLE - sole ownership; COMMON - tenants in common; JT - joint tenancy (deprecated); SO - sole ownership (deprecated); TC - tenants in common (deprecated)."
         },
         "status": {
             "type": "string",

--- a/src/registry_schemas/schemas/mhr/ownerGroup.json
+++ b/src/registry_schemas/schemas/mhr/ownerGroup.json
@@ -30,8 +30,8 @@
         "type": {
             "type": "string",
             "maxLength": 20,
-            "enum": ["JT", "SO", "TC"],
-            "description": "The type of owner."
+            "enum": ["JOINT", "SOLE", "COMMON", "JT", "SO", "TC"],
+            "description": "The type of owner group. JOINT - joint tenancy; SOLE - sole ownership; COMMON - tenants in common; JT - joint tenancy (deprecated); SO - sole ownership (deprecated); TC - tenants in common (deprecated)."
         },
         "status": {
             "type": "string",

--- a/src/registry_schemas/schemas/mhr/registration.json
+++ b/src/registry_schemas/schemas/mhr/registration.json
@@ -10,6 +10,12 @@
             "maxLength": 6,
             "description": "Unique manufactured home registration number assigned by the Manufactured Home Registry when a registration is created."
         },
+        "documentId": {
+            "type": [ "string", "null" ],
+            "maxLength": 8,
+            "minLength": 8,
+            "description": "Unique registration document ID/number required for new registrations as a reference to the decal; assigned by the Manufactured Home Registry."
+        },
         "status": {
             "type": [ "string", "null" ],
             "maxLength": 20,
@@ -20,6 +26,11 @@
             "type": [ "string", "null" ],
             "maxLength": 40,
             "description": "An optional client reference identifier associated with a change. Provided to facilitate client tracking of MHR activity."
+        },
+        "attentionReference": {
+            "type": [ "string", "null" ],
+            "maxLength": 40,
+            "description": "The registration document attention or reference information."
         },
         "declaredValue": {
             "type": [ "string", "null" ],
@@ -34,13 +45,6 @@
             "minItems": 1,
             "items": {
                 "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/mhr/ownerGroup"
-            }
-        },
-        "owners": {
-            "type": "array",
-            "minItems": 1,
-            "items": {
-                "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/mhr/owner"
             }
         },
         "location": {
@@ -81,7 +85,7 @@
         },
         {
             "required": [
-                "owners",
+                "ownerGroups",
                 "location",
                 "description"
             ]

--- a/src/registry_schemas/schemas/mhr/searchSummary.json
+++ b/src/registry_schemas/schemas/mhr/searchSummary.json
@@ -16,8 +16,8 @@
                 "status": {
                     "type": "string",
                     "maxLength": 10,
-                    "enum": ["ACTIVE", "EXEMPT", "HISTORIC"],
-                    "description": "The status of a manufactured home registration: one of ACTIVE, EXEMPT, or HISTORIC."
+                    "enum": ["ACTIVE", "EXEMPT", "HISTORICAL", "HISTORIC"],
+                    "description": "The status of a manufactured home registration: one of ACTIVE, EXEMPT, or HISTORICAL. HISTORIC is deprecated (replaced by HISTORICAL)."
                 },
                 "createDateTime": {
                     "type": "string",

--- a/tests/unit/common/test_party.py
+++ b/tests/unit/common/test_party.py
@@ -23,14 +23,11 @@ from registry_schemas.example_data.common import PARTY
 # testdata pattern is ({phone number}, {phone extension} {is valid})
 TEST_DATA_PHONE_NUM = [
     ('2504772707', None, True),
-    ('250 4772707', None, True),
-    ('250 477-2707', 'ext. 1234', True),
-    ('250 4772707', '12345', True),
-    ('250 477-2707', '546', True),
-    ('4772707', None, False),
-    ('477-2707', None, False),
-    ('250 477-2707', 'TOO LONG123', False),
-    ('250477270   TOO LONG12', None, False)
+    ('250477270', None, False),
+    ('250 4772707', None, False),
+    ('2504772707', '123', True),
+    ('2504772707', '12345', True),
+    ('2504772707', '123456', False)
 ]
 
 

--- a/tests/unit/mhr/test_owner.py
+++ b/tests/unit/mhr/test_owner.py
@@ -23,17 +23,21 @@ from registry_schemas.example_data.mhr import ADDRESS, PERSON_NAME
 LONG_ORG_NAME = '01234567890123456789012345678901234567890123456789012345678901234567890'
 SUFFIX_MAX_LENGTH = '0123456789012345678901234567890123456789012345678901234567890123456789'
 TEST_DATA_OWNER = [
-    ('Valid org active', True, 'org name', None, ADDRESS, 'SO', 'ACTIVE', None, None),
-    ('Valid ind exempt', True, None, PERSON_NAME, ADDRESS, 'SO', 'EXEMPT', None, 'suffix'),
-    ('Valid JT type previous', True, 'org name', None, ADDRESS, 'JT', 'PREVIOUS', None, 'suffix'),
+    ('Valid org active SO', True, 'org name', None, ADDRESS, 'SOLE', 'ACTIVE', None, None),
+    ('Valid org active SOLE', True, 'org name', None, ADDRESS, 'SOLE', 'ACTIVE', None, None),
+    ('Valid ind exempt', True, None, PERSON_NAME, ADDRESS, 'SOLE', 'EXEMPT', None, 'suffix'),
+    ('Valid JOINT type previous', True, 'org name', None, ADDRESS, 'JOINT', 'PREVIOUS', None, 'suffix'),
+    ('Valid COMMON type', True, 'org name', None, ADDRESS, 'COMMON', 'ACTIVE', '2501234567', SUFFIX_MAX_LENGTH),
+    ('Valid SO type', True, 'org name', None, ADDRESS, 'SO', 'ACTIVE', None, None),
+    ('Valid JT type', True, 'org name', None, ADDRESS, 'JT', 'PREVIOUS', None, 'suffix'),
     ('Valid TC type', True, 'org name', None, ADDRESS, 'TC', 'ACTIVE', '2501234567', SUFFIX_MAX_LENGTH),
-    ('Invalid missing owner', False, None, None, ADDRESS, 'SO', 'ACTIVE', '2501234567', 'suffix'),
-    ('Invalid missing address', False, 'org name', None, None, 'TC', 'ACTIVE', '2501234567', 'suffix'),
+    ('Invalid missing owner', False, None, None, ADDRESS, 'SOLE', 'ACTIVE', '2501234567', 'suffix'),
+    ('Invalid missing address', False, 'org name', None, None, 'COMMON', 'ACTIVE', '2501234567', 'suffix'),
     ('Invalid type', False, 'org name', None, ADDRESS, 'XX', 'ACTIVE', '2501234567', 'suffix'),
-    ('Invalid status', False, 'org name', None, ADDRESS, 'SO', 'XXX', '2501234567', 'suffix'),
-    ('Invalid phone too long', False, 'org name', None, ADDRESS, 'SO', 'ACTIVE', '2501234567          8', 'suffix'),
-    ('Invalid org too long', False, LONG_ORG_NAME, None, ADDRESS, 'SO', 'ACTIVE', '2501234567', 'suffix'),
-    ('Invalid suffix too long', False, LONG_ORG_NAME, None, ADDRESS, 'SO', 'ACTIVE', '2501234567',
+    ('Invalid status', False, 'org name', None, ADDRESS, 'SOLE', 'XXX', '2501234567', 'suffix'),
+    ('Invalid phone too long', False, 'org name', None, ADDRESS, 'SOLE', 'ACTIVE', '2501234567          8', 'suffix'),
+    ('Invalid org too long', False, LONG_ORG_NAME, None, ADDRESS, 'SOLE', 'ACTIVE', '2501234567', 'suffix'),
+    ('Invalid suffix too long', False, LONG_ORG_NAME, None, ADDRESS, 'SOLE', 'ACTIVE', '2501234567',
      SUFFIX_MAX_LENGTH + 'X')
 ]
 

--- a/tests/unit/mhr/test_owner_group.py
+++ b/tests/unit/mhr/test_owner_group.py
@@ -23,19 +23,22 @@ from registry_schemas.example_data.mhr import OWNER_GROUP
 LONG_INTEREST = '01234567890123456789'
 # testdata pattern is ({desc}, {valid}, {group_id}, {owners}, {interest}, {numerator}, {type}, {status})
 TEST_DATA_OWNER_GROUP = [
+    ('Valid SOLE type', True, 1, True, None, 0, 'SOLE', None),
+    ('Valid no group id', True, None, True, None, 0, 'SOLE', 'ACTIVE'),
+    ('Valid active', True, 1, True, None, 0, 'SOLE', 'ACTIVE'),
+    ('Valid exempt', True, 1, True, None, 0, 'SOLE', 'EXEMPT'),
+    ('Valid previous', True, 1, True, None, 0, 'SOLE', 'PREVIOUS'),
+    ('Valid JOINT type', True, 1, True, 'UNDIVIDED 1/2', 1, 'JOINT', 'ACTIVE'),
+    ('Valid COMMON type', True, 1, True, LONG_INTEREST, 1, 'COMMON', 'ACTIVE'),
     ('Valid SO type', True, 1, True, None, 0, 'SO', None),
-    ('Valid no group id', True, None, True, None, 0, 'SO', 'ACTIVE'),
-    ('Valid active', True, 1, True, None, 0, 'SO', 'ACTIVE'),
-    ('Valid exempt', True, 1, True, None, 0, 'SO', 'EXEMPT'),
-    ('Valid previous', True, 1, True, None, 0, 'SO', 'PREVIOUS'),
     ('Valid JT type', True, 1, True, 'UNDIVIDED 1/2', 1, 'JT', 'ACTIVE'),
     ('Valid TC type', True, 1, True, LONG_INTEREST, 1, 'TC', 'ACTIVE'),
-    ('Invalid missing owner', False, 1, False, None, 0, 'SO', None),
+    ('Invalid missing owner', False, 1, False, None, 0, 'SOLE', None),
     ('Invalid missing type', False, 1, True, None, 0, None, None),
     ('Invalid type', False, 1, True, None, 0, 'XX', None),
-    ('Invalid status', False, 1, True, None, 0, 'JT', 'XX'),
+    ('Invalid status', False, 1, True, None, 0, 'JOINT', 'XX'),
     ('Invalid numerator', False, 1, True, None, -1, None, None),
-    ('Invalid interest too long', False, 1, True, LONG_INTEREST + 'X', 1, 'TC', None)
+    ('Invalid interest too long', False, 1, True, LONG_INTEREST + 'X', 1, 'COMMON', None)
 ]
 
 

--- a/tests/unit/mhr/test_registration.py
+++ b/tests/unit/mhr/test_registration.py
@@ -133,7 +133,7 @@ def test_registration(desc, valid, mhr, status, ref, decv, haso, hasl, hasd, has
     if desc == 'Invalid doc id too long':
         data['documentId'] = data.get('documentId') + '9'
     elif desc == 'Invalid attention too long':
-        data['attentionReference'] =  LONG_ATTENTION_REF
+        data['attentionReference'] = LONG_ATTENTION_REF
 
     is_valid, errors = validate(data, 'registration', 'mhr')
 

--- a/tests/unit/mhr/test_registration.py
+++ b/tests/unit/mhr/test_registration.py
@@ -17,7 +17,7 @@ import copy
 import pytest
 
 from registry_schemas import validate
-from registry_schemas.example_data.mhr import OWNER, REGISTRATION
+from registry_schemas.example_data.mhr import REGISTRATION
 
 
 PARTY_VALID = {
@@ -61,9 +61,9 @@ PPR_REG_VALID = [
     }
 ]
 PPR_REG_EMPTY = []
-OWNERS = [OWNER]
 
 LONG_CLIENT_REF = '01234567890123456789012345678901234567890'
+LONG_ATTENTION_REF = '01234567890123456789012345678901234567890'
 
 # testdata pattern is ({desc},{valid},{mhr},{status},{rev},{decv},{haso},{hasl},{hasd},{hasn},{hasdt},{hasp})
 TEST_DATA_REG = [
@@ -72,9 +72,9 @@ TEST_DATA_REG = [
     ('Valid no ref', True, None, None, None, '50000.00', True, True, True, True, False, False),
     ('Valid no declared value', True, None, None, 'ref', None, True, True, True, True, False, False),
     ('Valid no notes', True, None, None, 'ref', '50000.00', True, True, True, False, False, False),
-    ('Valid owners', True, None, None, 'ref', '50000.00', True, True, True, False, False, False),
     ('Invalid no owner groups', False, None, None, 'ref', '50000.00', False, True, True, True, False, False),
-    ('Invalid no submitting party', False, None, None, 'ref', '50000.00', True, True, True, False, False, False),
+    ('Invalid doc id too long', False, None, None, 'ref', '50000.00', True, True, True, False, False, False),
+    ('Invalid attention too long', False, None, None, 'ref', '50000.00', True, True, True, False, False, False),
     ('Invalid no location', False, None, None, 'ref', '50000.00', True, False, True, True, False, False),
     ('Invalid no description', False, None, None, 'ref', '50000.00', True, True, False, True, False, False),
     ('Invalid mhr num too long', False, '1234567', None, 'ref', '50000.00', True, True, True, True, False, False),
@@ -130,32 +130,10 @@ def test_registration(desc, valid, mhr, status, ref, decv, haso, hasl, hasd, has
         del data['declaredValue']
     else:
         data['declaredValue'] = decv
-    if desc == 'Valid owners':
-        del data['ownerGroups']
-        data['owners'] = OWNERS
-    elif desc == 'Invalid no submitting party':
-        del data['submittingParty']
-
-    is_valid, errors = validate(data, 'registration', 'mhr')
-
-    if errors:
-        for err in errors:
-            print(err.message)
-
-    if valid:
-        assert is_valid
-    else:
-        assert not is_valid
-
-
-@pytest.mark.parametrize('desc,valid,sub_party', TEST_DATA_SUB_PARTY)
-def test_registration_reg_party(desc, valid, sub_party):
-    """Assert that the schema is performing as expected with a submitting party."""
-    data = copy.deepcopy(REGISTRATION)
-    if sub_party:
-        data['submittingParty'] = sub_party
-    else:
-        del data['submittingParty']
+    if desc == 'Invalid doc id too long':
+        data['documentId'] = data.get('documentId') + '9'
+    elif desc == 'Invalid attention too long':
+        data['attentionReference'] =  LONG_ATTENTION_REF
 
     is_valid, errors = validate(data, 'registration', 'mhr')
 

--- a/tests/unit/mhr/test_search_summary.py
+++ b/tests/unit/mhr/test_search_summary.py
@@ -55,6 +55,7 @@ SEARCH_SUMMARY_ORG = [
 TEST_DATA_STATUS = [
     ('ACTIVE', True),
     ('EXEMPT', True),
+    ('HISTORICAL', True),
     ('HISTORIC', True),
     ('XX', False)
 ]


### PR DESCRIPTION
Signed-off-by: Doug Lovett <doug@diamante.ca>

*Issue #:* /bcgov/entity#NA

*Description of changes:*
- common party schema update phoneNumber and phoneExtension lengths
- mhr registration schema remove owners, add documentId, attentionReference  
- mhr searchSummary schema update status add HISTORICAl to replace HISTORIC
- mhr owner, ownerGroup update type to include new data model values.
- Update example data and tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the registry-schemas license (Apache 2.0).
