### PR TITLE
MHR QS dealer schema updates

### DIFF
--- a/src/registry_schemas/schemas/mhr/adminRegistration.json
+++ b/src/registry_schemas/schemas/mhr/adminRegistration.json
@@ -18,7 +18,7 @@
         },
         "documentId": {
             "type": [ "string", "null" ],
-            "maxLength": 8,
+            "maxLength": 10,
             "minLength": 8,
             "description": "Unique registration document ID/number assigned by the Manufactured Home Registry."
         },
@@ -62,7 +62,7 @@
         },
         "updateDocumentId": {
             "type": [ "string", "null" ],
-            "maxLength": 8,
+            "maxLength": 10,
             "description": "Only required with NRED and COUR document type requests. It is the document ID of a previously created registration that is being cancelled or updated."
         },
         "note": {

--- a/src/registry_schemas/schemas/mhr/exemption.json
+++ b/src/registry_schemas/schemas/mhr/exemption.json
@@ -12,7 +12,7 @@
         },
         "documentId": {
             "type": [ "string", "null" ],
-            "maxLength": 8,
+            "maxLength": 10,
             "minLength": 8,
             "description": "Unique registration document ID/number assigned by the Manufactured Home Registry."
         },

--- a/src/registry_schemas/schemas/mhr/note.json
+++ b/src/registry_schemas/schemas/mhr/note.json
@@ -12,7 +12,7 @@
         },
        "documentId": {
             "type": "string",
-            "maxLength": 8,
+            "maxLength": 10,
             "description": "The unique document ID for the registration associated with the note."
         },
         "documentRegistrationNumber": {

--- a/src/registry_schemas/schemas/mhr/noteRegistration.json
+++ b/src/registry_schemas/schemas/mhr/noteRegistration.json
@@ -38,7 +38,7 @@
         },
         "cancelDocumentId": {
             "type": [ "string", "null" ],
-            "maxLength": 8,
+            "maxLength": 10,
             "description": "Only included in requests for the NCAN document type, the document ID of the previously created unit note registration that is being cancelled."
         },
         "payment": {

--- a/src/registry_schemas/schemas/mhr/qualifiedSupplier.json
+++ b/src/registry_schemas/schemas/mhr/qualifiedSupplier.json
@@ -44,6 +44,14 @@
         "termsAccepted": {
             "type": "boolean",
             "description": "Included in the POST response to indicate the terms of agreement document has been accepted by the account submitting the request."
+        },
+        "confirmRequirements": {
+            "type": "boolean",
+            "description": "Applies to QS dealers: indicates that the dealer has confirmed acceptance of additional requirements regarding registrations."
+        },
+        "locationAddress": {
+            "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/common/address",
+            "description": "Applies to QS dealers: specifies the location address for transport permit related registrations."
         }
     },
     "anyOf":[

--- a/src/registry_schemas/schemas/mhr/registration.json
+++ b/src/registry_schemas/schemas/mhr/registration.json
@@ -17,7 +17,7 @@
         },
         "documentId": {
             "type": [ "string", "null" ],
-            "maxLength": 8,
+            "maxLength": 10,
             "minLength": 8,
             "description": "Unique registration document ID/number required for new registrations as a reference to the decal; assigned by the Manufactured Home Registry."
         },

--- a/src/registry_schemas/schemas/mhr/registrationSummary.json
+++ b/src/registry_schemas/schemas/mhr/registrationSummary.json
@@ -12,7 +12,7 @@
         },
         "documentId": {
             "type": [ "string", "null" ],
-            "maxLength": 8,
+            "maxLength": 10,
             "minLength": 8,
             "description": "Unique registration document ID/number assigned by the Manufactured Home Registry."
         },

--- a/src/registry_schemas/schemas/mhr/transfer.json
+++ b/src/registry_schemas/schemas/mhr/transfer.json
@@ -17,7 +17,7 @@
         },
         "documentId": {
             "type": [ "string", "null" ],
-            "maxLength": 8,
+            "maxLength": 10,
             "minLength": 8,
             "description": "Unique registration document ID/number assigned by the Manufactured Home Registry."
         },

--- a/src/registry_schemas/schemas/mhr/transportPermit.json
+++ b/src/registry_schemas/schemas/mhr/transportPermit.json
@@ -17,7 +17,7 @@
         },
         "documentId": {
             "type": [ "string", "null" ],
-            "maxLength": 8,
+            "maxLength": 10,
             "minLength": 8,
             "description": "Unique registration document ID/number assigned by the Manufactured Home Registry."
         },

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.11'  # pylint: disable=invalid-name
+__version__ = '1.8.12'  # pylint: disable=invalid-name

--- a/tests/unit/mhr/test_admin_registration.py
+++ b/tests/unit/mhr/test_admin_registration.py
@@ -86,7 +86,7 @@ def test_admin_registration(desc, valid, doc_type, has_sub, is_request, client_r
         del data['payment']
         del data['registrationType']
     if desc == 'Invalid update doc id':
-        data['updateDocumentId'] = '123456789'
+        data['updateDocumentId'] = '01234567890'
     elif desc in ('Valid request STAT',
                   'Valid request CANCEL_PERMIT',
                   'Valid response CANCEL_PERMIT'):

--- a/tests/unit/mhr/test_note.py
+++ b/tests/unit/mhr/test_note.py
@@ -37,7 +37,7 @@ TEST_DATA_NOTE = [
     ('Valid no remarks', True, 'type', '123456', True, True, None, 'contact', ADDRESS),
     ('Invalid no type', False, None, '123456', True, True, 'remarks', 'contact', ADDRESS),
     ('Invalid type too long', False, '012345678901234567891', '123456', True, True, 'remarks', 'contact', ADDRESS),
-    ('Invalid doc id too long', False, '1234', '123456789', True, True, 'remarks', 'contact', ADDRESS),
+    ('Invalid doc id too long', False, '1234', '01234567890', True, True, 'remarks', 'contact', ADDRESS),
     ('Invalid contact too long', False, '1234', '123456', True, True, 'remarks', LONG_NAME, ADDRESS)
 ]
 # testdata pattern is ({valid},{reason},{other})

--- a/tests/unit/mhr/test_note_registration.py
+++ b/tests/unit/mhr/test_note_registration.py
@@ -34,7 +34,7 @@ TEST_DATA = [
 TEST_DATA_CANCEL = [
     ('Valid request', True, '12345678', True, None, None, None),
     ('Valid response', True, None, False, 'CAU', '00545678', 'NOTICE OF CAUTION'),
-    ('Invalid request doc id', False, '123456789', True, None, None, None)
+    ('Invalid request doc id', False, '01234567890', True, None, None, None)
 ]
 
 

--- a/tests/unit/mhr/test_qualified_supplier.py
+++ b/tests/unit/mhr/test_qualified_supplier.py
@@ -23,6 +23,14 @@ from registry_schemas.example_data.mhr import QUALIFIED_SUPPLIER
 NAME_50 = '01234567890123456789012345678901234567890123456789'
 BUS_MAX_LENGTH = NAME_50 + NAME_50 + NAME_50
 DBA_MAX_LENGTH = NAME_50 + NAME_50 + NAME_50
+LOCATION_ADDRESS = {
+    'street': '520 Location St',
+    'city': 'Victoria',
+    'region': 'BC',
+    'country': 'CA',
+    'postalCode': 'V8S 2V4'
+}
+
 
 # testdata pattern is ({desc},{valid},{bus},{dba},{phone},{email},{has_address})
 TEST_DATA_SUPPLIER = [
@@ -36,6 +44,41 @@ TEST_DATA_SUPPLIER = [
     ('Invalid dba name', False, 'BUS NAME', DBA_MAX_LENGTH + 'X', None, None, True),
     ('Invalid email', False, 'BUS NAME', None, None, 'invalid format', True)
 ]
+# testdata pattern is ({desc},{valid},{confirm_req},{loc_address})
+TEST_DATA_DEALER = [
+    ('Valid all', True, True, LOCATION_ADDRESS),
+    ('Valid no confirm req', True, None, LOCATION_ADDRESS),
+    ('Valid confirm req false', True, False, LOCATION_ADDRESS),
+    ('Valid no loc address', True, True, None),
+    ('Invalid address', False, True, LOCATION_ADDRESS)
+]
+
+
+@pytest.mark.parametrize('desc,valid, confirm_req, loc_address', TEST_DATA_DEALER)
+def test_dealer(desc, valid, confirm_req, loc_address):
+    """Assert that the schema is performing as expected for dealer information."""
+    data = copy.deepcopy(QUALIFIED_SUPPLIER)
+    del data['phoneExtension']
+    if confirm_req is not None:
+        if confirm_req:
+            data['confirmRequirements'] = True
+        else:
+            data['confirmRequirements'] = False
+    if loc_address:
+        address = copy.deepcopy(loc_address)
+        if desc == 'Invalid address':
+            del address['postalCode']
+        data['locationAddress'] = address
+
+    is_valid, errors = validate(data, 'qualifiedSupplier', 'mhr')
+
+    if errors:
+        for err in errors:
+            print(err.message)
+    if valid:
+        assert is_valid
+    else:
+        assert not is_valid
 
 
 @pytest.mark.parametrize('desc,valid,bus_name,dba_name,phone,email,has_address', TEST_DATA_SUPPLIER)

--- a/tests/unit/mhr/test_registration.py
+++ b/tests/unit/mhr/test_registration.py
@@ -180,7 +180,7 @@ def test_registration(desc, valid, mhr, status, ref, decv, haso, hasl, hasd, has
     else:
         data['declaredValue'] = decv
     if desc == 'Invalid doc id too long':
-        data['documentId'] = data.get('documentId') + '9'
+        data['documentId'] = data.get('documentId') + '999'
     elif desc == 'Invalid attention too long':
         data['attentionReference'] = LONG_ATTENTION_REF
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24172

*Description of changes:*
- Update document ID length from 8 to 10 in all schemas.
- Add confirmRequirements, locationAddress to MHR qualified supplier schema.
- Update unit tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the registry-schemas license (Apache 2.0).
