### PR TITLE
MHR transfer owner edit information

### DIFF
--- a/src/registry_schemas/schemas/mhr/adminRegistration.json
+++ b/src/registry_schemas/schemas/mhr/adminRegistration.json
@@ -72,7 +72,7 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/mhr/ownerGroup"
+                "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/mhr/deleteOwnerGroup"
             }
         },
         "addOwnerGroups": {

--- a/src/registry_schemas/schemas/mhr/deleteOwnerGroup.json
+++ b/src/registry_schemas/schemas/mhr/deleteOwnerGroup.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/mhr/deleteOwnerGroup",
+    "type": "object",
+    "title": "The MHR Delete Owner Group Schema - skip owner validation",
+    "definitions": {},
+    "properties": {
+       "groupId": {
+            "type": "integer",
+            "mimimum": 1,
+            "description": "Assigned by the system if not provided. Starts with 1 and increments for each group associated with a home."
+        },
+        "type": {
+            "type": "string",
+            "maxLength": 20,
+            "enum": ["COMMON", "JOINT", "SOLE", "NA", "JT", "SO", "TC"],
+            "description": "The type of owner group (tenancy type). COMMON - tenants in common; JOINT - joint tenancy; SOLE - sole ownership; NA - not applicable; JT - joint tenancy (deprecated); SO - sole ownership (deprecated); TC - tenants in common (deprecated)."
+        },
+        "status": {
+            "type": "string",
+            "maxLength": 20,
+            "description": "The status of the owner."
+        }
+    },
+    "required": [
+        "groupId",
+        "type"
+    ]
+}

--- a/src/registry_schemas/schemas/mhr/owner.json
+++ b/src/registry_schemas/schemas/mhr/owner.json
@@ -73,6 +73,11 @@
             "type": "string",
             "maxLength": 20,
             "description": "Include only for transfer due to death registration types when the owner is in the deleteOwnerGroups, not added, and is a business/organization."
+        },
+        "previousOwnerId": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Optional for an addOwnerGroups owner, used in transfer registrations to indicate the owner information has been changed except for the name. In other words, the previousOwnerId in an an addOwnerGroups owner maps to an ownerId in a deleteOwnerGroups owner and the names must be identical."
         }
     },
     "oneOf":[

--- a/src/registry_schemas/schemas/mhr/transfer.json
+++ b/src/registry_schemas/schemas/mhr/transfer.json
@@ -60,7 +60,7 @@
             "type": "array",
             "minItems": 1,
             "items": {
-                "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/mhr/ownerGroup"
+                "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/mhr/deleteOwnerGroup"
             }
         },
         "addOwnerGroups": {

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.12'  # pylint: disable=invalid-name
+__version__ = '1.8.13'  # pylint: disable=invalid-name

--- a/tests/unit/mhr/test_admin_registration.py
+++ b/tests/unit/mhr/test_admin_registration.py
@@ -24,6 +24,36 @@ LONG_CLIENT_REF = '012345678901234567890123456789012345678901234567890'
 OWNER_GROUPS = [
     OWNER_GROUP
 ]
+ADDRESS1 = {
+  'city': 'delivery_address city',
+  'region': 'BC',
+  'postalCode': 'V8S2J9',
+  'country': 'CA'
+}
+ADDRESS2 = {
+  'street': 'delivery_address - address line one',
+  'region': 'BC',
+  'postalCode': 'V8S2J9',
+  'country': 'CA'
+}
+ADDRESS3 = {
+  'street': 'delivery_address - address line one',
+  'city': 'delivery_address city',
+  'postalCode': 'V8S2J9',
+  'country': 'CA'
+}
+ADDRESS4 = {
+  'street': 'delivery_address - address line one',
+  'city': 'delivery_address city',
+  'region': 'BC',
+  'country': 'CA'
+}
+ADDRESS5 = {
+  'street': 'delivery_address - address line one',
+  'city': 'delivery_address city',
+  'region': 'BC',
+  'postalCode': 'V8S2J9'
+}
 # testdata pattern is ({desc},{valid},{doc_type},{has_submitting},{is_request},{client_ref}, {attention})
 TEST_DATA = [
     ('Valid request COUR', True, 'COUR', True, True, None, None),
@@ -60,7 +90,16 @@ TEST_DATA_AMEND_CORRECT = [
     ('Invalid staff correction description', False, 'REGC_STAFF', None, None, DESCRIPTION, None),
     ('Invalid amendment owners', False, 'PUBA', None, None, None, OWNER_GROUPS),
 ]
-
+# testdata pattern is ({desc},{valid},{doc_type},{delete_owners},{delete_address})
+TEST_DATA_AMEND_CORRECT_OWNERS = [
+   ('Valid amendment', True, 'PUBA', False, None),
+   ('Valid correction no owners', True, 'REGC_STAFF', True, None),
+   ('Valid no address street', True, 'PUBA', False, ADDRESS1),
+   ('Valid no address city', True, 'PUBA', False, ADDRESS2),
+   ('Valid no address region', True, 'PUBA', False, ADDRESS3),
+   ('Valid no address pcode', True, 'PUBA', False, ADDRESS4),
+   ('Valid no address country', True, 'PUBA', False, ADDRESS5),
+ ]
 
 @pytest.mark.parametrize('desc,valid,doc_type,has_sub,is_request,client_ref,attention', TEST_DATA)
 def test_admin_registration(desc, valid, doc_type, has_sub, is_request, client_ref, attention):
@@ -139,6 +178,37 @@ def test_admin_amend_correct(desc, valid, doc_type, status, location, descriptio
             bad_owners = copy.deepcopy(owner_group)
             del bad_owners[0]['type']
             data['addOwnerGroups'] = bad_owners
+
+    is_valid, errors = validate(data, 'adminRegistration', 'mhr')
+
+    if errors:
+        for err in errors:
+            print(err.message)
+
+    if valid:
+        assert is_valid
+    else:
+        assert not is_valid
+
+
+@pytest.mark.parametrize('desc,valid,doc_type,del_owners,del_address', TEST_DATA_AMEND_CORRECT_OWNERS)
+def test_admin_amend_correct_owners(desc, valid, doc_type, del_owners, del_address):
+    """Assert that the staff admin registration schema is performing as expected for amendments/corrections."""
+    data = copy.deepcopy(ADMIN_REGISTRATION)
+    add_group = copy.deepcopy(OWNER_GROUPS)
+    del_group = copy.deepcopy(OWNER_GROUPS)
+    data['documentType'] = doc_type
+    del data['mhrNumber']
+    del data['createDateTime']
+    del data['payment']
+    del data['registrationType']
+    data['addOwnerGroups'] = add_group
+    if del_address:
+        for owner in del_group[0].get('owners'):
+            owner['address'] = del_address
+    elif del_owners:
+        del del_group[0]['owners']
+    data['deleteOwnerGroups'] = del_group
 
     is_valid, errors = validate(data, 'adminRegistration', 'mhr')
 

--- a/tests/unit/mhr/test_admin_registration.py
+++ b/tests/unit/mhr/test_admin_registration.py
@@ -101,6 +101,7 @@ TEST_DATA_AMEND_CORRECT_OWNERS = [
    ('Valid no address country', True, 'PUBA', False, ADDRESS5),
  ]
 
+
 @pytest.mark.parametrize('desc,valid,doc_type,has_sub,is_request,client_ref,attention', TEST_DATA)
 def test_admin_registration(desc, valid, doc_type, has_sub, is_request, client_ref, attention):
     """Assert that the staff admin registration schema is performing as expected."""

--- a/tests/unit/mhr/test_admin_registration.py
+++ b/tests/unit/mhr/test_admin_registration.py
@@ -210,7 +210,6 @@ def test_admin_amend_correct_owners(desc, valid, doc_type, del_owners, del_addre
     elif del_owners:
         del del_group[0]['owners']
     data['deleteOwnerGroups'] = del_group
-
     is_valid, errors = validate(data, 'adminRegistration', 'mhr')
 
     if errors:

--- a/tests/unit/mhr/test_owner.py
+++ b/tests/unit/mhr/test_owner.py
@@ -40,7 +40,8 @@ TEST_DATA_OWNER = [
     ('Invalid phone too long', False, 'org name', None, ADDRESS, 'SOLE', 'ACTIVE', '2501234567          8', 'suffix'),
     ('Invalid org too long', False, LONG_ORG_NAME, None, ADDRESS, 'SOLE', 'ACTIVE', '2501234567', 'suffix'),
     ('Invalid suffix too long', False, LONG_ORG_NAME, None, ADDRESS, 'SOLE', 'ACTIVE', '2501234567',
-     SUFFIX_MAX_LENGTH + 'X')
+     SUFFIX_MAX_LENGTH + 'X'),
+    ('Invalid previous owner id', False, 'org name', None, ADDRESS, 'SOLE', 'ACTIVE', None, None)
 ]
 # testdata pattern is ({valid}, {party_type}, {party_desc})
 TEST_DATA_OWNER_PARTY_TYPE = [
@@ -89,7 +90,10 @@ def test_owner(desc, valid, org, individual, address, type, status, phone, suffi
         data['phoneNumber'] = phone
     if suffix:
         data['suffix'] = suffix
-
+    if desc == 'Valid org active SO':
+        data['previousOwnerId'] = 1
+    elif desc == 'Invalid previous owner id':
+        data['previousOwnerId'] = 0
     is_valid, errors = validate(data, 'owner', 'mhr')
 
     if errors:

--- a/tests/unit/mhr/test_owner_group.py
+++ b/tests/unit/mhr/test_owner_group.py
@@ -21,6 +21,37 @@ from registry_schemas.example_data.mhr import OWNER_GROUP
 
 
 LONG_INTEREST = '01234567890123456789'
+ADDRESS1 = {
+  'city': 'delivery_address city',
+  'region': 'BC',
+  'postalCode': 'V8S2J9',
+  'country': 'CA'
+}
+ADDRESS2 = {
+  'street': 'delivery_address - address line one',
+  'region': 'BC',
+  'postalCode': 'V8S2J9',
+  'country': 'CA'
+}
+ADDRESS3 = {
+  'street': 'delivery_address - address line one',
+  'city': 'delivery_address city',
+  'postalCode': 'V8S2J9',
+  'country': 'CA'
+}
+ADDRESS4 = {
+  'street': 'delivery_address - address line one',
+  'city': 'delivery_address city',
+  'region': 'BC',
+  'country': 'CA'
+}
+ADDRESS5 = {
+  'street': 'delivery_address - address line one',
+  'city': 'delivery_address city',
+  'region': 'BC',
+  'postalCode': 'V8S2J9'
+}
+
 # testdata pattern is ({desc}, {valid}, {group_id}, {owners}, {interest}, {numerator}, {type}, {status}, {denominator})
 TEST_DATA_OWNER_GROUP = [
     ('Valid SOLE type', True, 1, True, None, 0, 'SOLE', None, None),
@@ -42,6 +73,54 @@ TEST_DATA_OWNER_GROUP = [
     ('Invalid denominator', False, 1, True, None, 1, None, None, -1),
     ('Invalid interest too long', False, 1, True, LONG_INTEREST + 'X', 1, 'COMMON', None, None)
 ]
+# testdata pattern is ({desc}, {valid}, {group_id}, {owners}, {type}, {status}, {address})
+TEST_DATA_DELETE_GROUP = [
+    ('Valid SOLE type', True, 1, True, 'SOLE', None, None),
+    ('Valid JOINT type', True, 1, True, 'JOINT', None, None),
+    ('Valid COMMON type', True, 1, True, 'COMMON', None, None),
+    ('Valid NA type', True, 1, True, 'NA', None, None),
+    ('Valid no owners', True, 1, None, 'SOLE', None, None),
+    ('Invalid no group id', False, None, True, 'SOLE', 'ACTIVE', None),
+    ('Invalid missing type', False, 1, True, None, 'ACTIVE', None),
+    ('Valid no address street', True, 1, True, 'SOLE', None, ADDRESS1),
+    ('Valid no address city', True, 1, True, 'SOLE', None, ADDRESS2),
+    ('Valid no address region', True, 1, True, 'SOLE', None, ADDRESS3),
+    ('Valid no address pcode', True, 1, True, 'SOLE', None, ADDRESS4),
+    ('Valid no address country', True, 1, True, 'SOLE', None, ADDRESS5)
+]
+
+
+@pytest.mark.parametrize('desc,valid,group_id,owners,type,status,address', TEST_DATA_DELETE_GROUP)
+def test_delete_group(desc, valid, group_id, owners, type, status, address):
+    """Assert that the schema is performing as expected for the delete owner group."""
+    data = copy.deepcopy(OWNER_GROUP)
+    if not owners:
+        del data['owners']
+    if group_id:
+        data['groupId'] = group_id
+    else:
+        del data['groupId']
+    if type:
+        data['type'] = type
+    else:
+        del data['type']
+    if status:
+        data['status'] = status
+    else:
+        del data['status']
+    if address:
+        for owner in data.get('owners'):
+            owner['address'] = address
+    is_valid, errors = validate(data, 'deleteOwnerGroup', 'mhr')
+
+    if errors:
+        for err in errors:
+            print(err.message)
+
+    if valid:
+        assert is_valid
+    else:
+        assert not is_valid
 
 
 @pytest.mark.parametrize('desc,valid,group_id,owners,interest,numerator,type,status,denominator', TEST_DATA_OWNER_GROUP)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24303

*Description of changes:*
- add previousOwnerId to owner schema.
- add deleteOwnerGroup schema to skip owner validation on deleted owner groups.
- Update unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the registry-schemas license (Apache 2.0).
