### PR TITLE
PPR API add new commercial lien registration type.

### DIFF
--- a/src/registry_schemas/schemas/ppr/draftSummary.json
+++ b/src/registry_schemas/schemas/ppr/draftSummary.json
@@ -21,8 +21,8 @@
                 },
                 "registrationType": {
                     "type": "string",
-                    "enum": ["SA", "RL", "FR", "LT", "MH", "SG", "FL", "FA", "FS", "MR", "AM", "CO", "AC", "DR", "DT", "PD", "ST", "SU", "SE"],
-                    "description": "For a Financing Statement the draft type value. For a Change Statement and an Amendment Statement the changeType value."
+                    "maxLength": 2,
+                    "description": "For a Financing Statement one of the defined registration types. For a Change Statement and an Amendment Statement the changeType value."
                 },
                 "documentId": {
                     "type": "string",

--- a/src/registry_schemas/schemas/ppr/financingStatement.json
+++ b/src/registry_schemas/schemas/ppr/financingStatement.json
@@ -3,7 +3,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/ppr/financingStatement",
     "type": "object",
-    "title": "The PPR Financning Statement Schema",
+    "title": "The PPR Financing Statement Schema",
     "properties": {
         "type": {
             "type": "string",
@@ -11,7 +11,7 @@
             "enum": ["SA", "RL", "FR", "LT", "MH", "SG", "FL", "FA", "FS", "MR", "CC", "CT", "DP", "ET", "FO", "FT"
                 , "HR", "IP", "LO", "MI", "OT"
                 , "PG", "PS", "IT", "RA", "SS", "TL", "HN", "ML", "MN", "PN", "WL", "TF", "TA", "TG", "TM", "MD", "PT"
-                , "SC", "TO", "SV", "SE"],
+                , "SC", "TO", "SV", "SE", "CL"],
             "description": "Specifies the type of Financing Statement. Includes all legacy registration types."
         },
         "clientReferenceId": {

--- a/src/registry_schemas/schemas/ppr/searchSummary.json
+++ b/src/registry_schemas/schemas/ppr/searchSummary.json
@@ -29,7 +29,7 @@
                     "type": "string",
                     "maxLength": 2,
                     "enum": ["SA", "RL", "FR", "LT", "MH", "SG", "FL", "FA", "FS", "MR", "CC", "CT", "DP", "ET", "FO", "FT", "HR", "IP", "LO", "MI", "OT"
-                        , "PG", "PS", "IT", "RA", "SS", "TL", "HN", "ML", "MN", "PN", "WL", "TF", "TA", "TG", "TM", "MD", "PT", "SC", "TO", "SV", "SE"],
+                        , "PG", "PS", "IT", "RA", "SS", "TL", "HN", "ML", "MN", "PN", "WL", "TF", "TA", "TG", "TM", "MD", "PT", "SC", "TO", "SV", "SE", "CL"],
                     "description": "Specifies the type of Financing Statement. Includes all legacy registration types."
                 },
                 "debtor": {

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.13'  # pylint: disable=invalid-name
+__version__ = '1.8.14'  # pylint: disable=invalid-name

--- a/tests/unit/ppr/test_financing_statement.py
+++ b/tests/unit/ppr/test_financing_statement.py
@@ -80,6 +80,7 @@ TEST_DATA_REG_TYPE = [
     ('SV', True),
     ('TO', True),
     ('SE', True),
+    ('CL', True),
     ('XX', False),
 ]
 # testdata pattern is ({other type description}, {is valid})

--- a/tests/unit/ppr/test_registration_summary.py
+++ b/tests/unit/ppr/test_registration_summary.py
@@ -36,7 +36,7 @@ TEST_VALID_ALL = {
 }
 TEST_VALID_MINIMUM = {
     'registrationNumber': '9000100B',
-    'registrationType': 'SA',
+    'registrationType': 'CL',
     'registrationClass': 'PPSALIEN',
     'path': '/ppr/api/v1/financing-statements/9000100B',
     'createDateTime': '2021-06-03T22:58:45+00:00'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24911

*Description of changes:*
- Add CL registrationType to financingStatement schema.
- Update unit tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the registry-schemas license (Apache 2.0).
