### PR TITLE
MHR post migration increase property lengths

### DIFF
--- a/src/registry_schemas/schemas/mhr/baseInformation.json
+++ b/src/registry_schemas/schemas/mhr/baseInformation.json
@@ -12,12 +12,12 @@
         },
         "make": {
             "type": [ "string", "null" ],
-            "maxLength": 65,
+            "maxLength": 60,
             "description": "Make of home."
         },
         "model": {
             "type": [ "string", "null" ],
-            "maxLength": 65,
+            "maxLength": 60,
             "description": "Model name."
         },
         "circa": {

--- a/src/registry_schemas/schemas/mhr/owner.json
+++ b/src/registry_schemas/schemas/mhr/owner.json
@@ -51,7 +51,7 @@
         },
         "suffix": {
             "type": "string",
-            "maxLength": 70,
+            "maxLength": 100,
             "description": "The organization or individual name suffix."
         },
         "deathCertificateNumber": {

--- a/src/registry_schemas/schemas/mhr/owner.json
+++ b/src/registry_schemas/schemas/mhr/owner.json
@@ -12,7 +12,7 @@
         },
        "organizationName": {
             "type": "string",
-            "maxLength": 70,
+            "maxLength": 150,
             "description": "The organization/business name of the owner."
         },
         "individualName": {

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.8.14'  # pylint: disable=invalid-name
+__version__ = '1.8.15'  # pylint: disable=invalid-name

--- a/tests/unit/mhr/test_owner.py
+++ b/tests/unit/mhr/test_owner.py
@@ -21,11 +21,13 @@ from registry_schemas.example_data.mhr import ADDRESS, OWNER, PERSON_NAME
 
 
 # testdata pattern is ({desc}, {valid}, {org}, {individual}, {address}, {type}, {status}, {phone}, {suffix})
-LONG_ORG_NAME = '01234567890123456789012345678901234567890123456789012345678901234567890'
-SUFFIX_MAX_LENGTH = '0123456789012345678901234567890123456789012345678901234567890123456789'
+TEXT_60 = '012345678901234567890123456789012345678901234567890123456789'
+TEXT_30 = '012345678901234567890123456789'
+LONG_ORG_NAME = TEXT_60 + TEXT_60 + TEXT_30
+SUFFIX_MAX_LENGTH = '0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789'
 TEST_DATA_OWNER = [
     ('Valid org active SO', True, 'org name', None, ADDRESS, 'SOLE', 'ACTIVE', None, None),
-    ('Valid org active SOLE', True, 'org name', None, ADDRESS, 'SOLE', 'ACTIVE', None, None),
+    ('Valid org active SOLE', True, LONG_ORG_NAME, None, ADDRESS, 'SOLE', 'ACTIVE', None, None),
     ('Valid ind exempt', True, None, PERSON_NAME, ADDRESS, 'SOLE', 'EXEMPT', None, 'suffix'),
     ('Valid JOINT type previous', True, 'org name', None, ADDRESS, 'JOINT', 'PREVIOUS', None, 'suffix'),
     ('Valid COMMON type', True, 'org name', None, ADDRESS, 'COMMON', 'ACTIVE', '2501234567', SUFFIX_MAX_LENGTH),
@@ -38,7 +40,7 @@ TEST_DATA_OWNER = [
     ('Invalid type', False, 'org name', None, ADDRESS, 'XX', 'ACTIVE', '2501234567', 'suffix'),
     ('Invalid status', False, 'org name', None, ADDRESS, 'SOLE', 'XXX', '2501234567', 'suffix'),
     ('Invalid phone too long', False, 'org name', None, ADDRESS, 'SOLE', 'ACTIVE', '2501234567          8', 'suffix'),
-    ('Invalid org too long', False, LONG_ORG_NAME, None, ADDRESS, 'SOLE', 'ACTIVE', '2501234567', 'suffix'),
+    ('Invalid org too long', False, LONG_ORG_NAME + 'X', None, ADDRESS, 'SOLE', 'ACTIVE', '2501234567', 'suffix'),
     ('Invalid suffix too long', False, LONG_ORG_NAME, None, ADDRESS, 'SOLE', 'ACTIVE', '2501234567',
      SUFFIX_MAX_LENGTH + 'X'),
     ('Invalid previous owner id', False, 'org name', None, ADDRESS, 'SOLE', 'ACTIVE', None, None)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29829

*Description of changes:*
- Set baseInformation schema make, model maximum lengths to 60.
- Set owner schema suffix maximum length to 100, organizationName maximum length to 150 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the registry-schemas license (Apache 2.0).
